### PR TITLE
chore: add GitHub Sponsors funding.yml and sponsor badge

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: slydlake

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenMediaVault (OMV) for Home Assistant
 
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://hacs.xyz)
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/slydlake)
 
 Monitor and control your OpenMediaVault NAS from Home Assistant.
 


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` with `github: slydlake` to show the Sponsor button on the repo page
- Adds a GitHub Sponsors badge to `README.md`