### PR TITLE
Expose openmediavault-tempmon sensors for accurate CPU temperature readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- TempMon sensor support: temperature sensors configured via the `openmediavault-tempmon` plugin are automatically exposed as HA entities. Each sensor appears as a dedicated temperature entity on the OMV hub device, named after the label set in OMV. Enables correct CPU temperature readings on ARM boards (e.g. Rock5 ITX / Armbian) where OMV's built-in `CpuTemp` plugin reports 0 °C.
+
 ## [2.3.0] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.4.0] - 2026-06-02
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Never hard-code English `_attr_name`. Use `translation_key` + `_attr_translation
 | `kvm` | KVM virtual machines |
 | `zfs` | ZFS pool status |
 | `raid` | RAID arrays |
+| `tempmon` | Temperature sensors from `openmediavault-tempmon` plugin (empty list when plugin absent) |
 
 ### API Client Gotchas
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ After setup, the options flow lets you adjust:
 
 - Pool status
 
+### TempMon sensors (requires `openmediavault-tempmon`)
+
+The [`openmediavault-tempmon`](https://github.com/openmediavault-plugin-developers/openmediavault-tempmon) plugin lets you expose any temperature sensor on the OMV host to Home Assistant. Each configured sensor becomes its own HA entity (named after the sensor name you set in OMV).
+
+**Use case: ARM CPU temperature (e.g. Rock5 ITX / Armbian)**
+
+OMV's built-in CPU temperature sensor reads from `thermal_zone0`, which returns 0 on many ARM SoCs. Install `openmediavault-tempmon` via OMV-Extras and configure a custom sensor:
+
+| Field | Value |
+|---|---|
+| Name | `CPU Temp` (or any label) |
+| Script path | `/usr/bin/cat /sys/class/hwmon/hwmon0/temp1_input` |
+| Divisor | `1000` (sensor reports millidegrees) |
+
+Once saved in OMV, the integration picks up the sensor automatically on the next coordinator refresh. No integration restart required.
+
+> **Tip:** The correct hwmon path varies by board. Check `/etc/armbianmonitor/datasources/soctemp` on Armbian systems — it is a symlink to the right input file.
+
 ### OMV service devices
 
 - Binary sensor: service running / not running

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ OMV's built-in CPU temperature sensor reads from `thermal_zone0`, which returns 
 
 | Field | Value |
 |---|---|
-| Name | `CPU Temp` (or any label) |
 | Script path | `/usr/bin/cat /sys/class/hwmon/hwmon0/temp1_input` |
 | Divisor | `1000` (sensor reports millidegrees) |
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ OMV's built-in CPU temperature sensor reads from `thermal_zone0`, which returns 
 
 | Field | Value |
 |---|---|
-| Script path | `/usr/bin/cat /sys/class/hwmon/hwmon0/temp1_input` |
+| Name | `CPU Temp` (or any label) |
+| Script path | `/usr/sbin/cpu-temp` |
+| Script | `cat /sys/class/hwmon/hwmon0/temp1_input` |
 | Divisor | `1000` (sensor reports millidegrees) |
 
 Once saved in OMV, the integration picks up the sensor automatically on the next coordinator refresh. No integration restart required.

--- a/custom_components/omv/coordinator.py
+++ b/custom_components/omv/coordinator.py
@@ -237,6 +237,9 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "kvm": self._normalize_named_collection(
                     await self._fetch_optional("Kvm", "getVmList", {"start": 0, "limit": 999})
                 ),
+                "tempmon": self._normalize_tempmon(
+                    await self._fetch_optional("TempMon", "getSensorsList", {"start": 0, "limit": 100})
+                ),
                 "zfs": zfs_pools,
                 "raid": raids,
                 "gpu": gpu,
@@ -499,6 +502,7 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             filtered["service"],
         )
         filtered["kvm"] = list(data.get("kvm", []))
+        filtered["tempmon"] = list(data.get("tempmon", []))
         filtered["gpu"] = data.get("gpu", {})
         filtered["upgradedList"] = list(data.get("upgradedList", []))
         return filtered
@@ -1398,6 +1402,34 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _normalize_named_collection(self, response: Any) -> list[dict[str, Any]]:
         """Normalize plugin collections that already contain flat object data."""
         return self._records_from_response(response)
+
+    def _normalize_tempmon(self, response: Any) -> list[dict[str, Any]]:
+        """Normalize openmediavault-tempmon sensor list into coordinator records.
+
+        Args:
+            response: Raw response from TempMon.getSensorsList.
+
+        Returns:
+            List of sensor dicts with sensor_key, name, widgetgroup, and temperature.
+        """
+        result: list[dict[str, Any]] = []
+        for record in self._records_from_response(response):
+            uuid = str(record.get("uuid") or "")
+            if not uuid:
+                continue
+            raw_temp = str(record.get("currenttemp") or "").strip()
+            temp: float | None = None
+            if raw_temp and raw_temp != "-":
+                temp = self._coerce_optional_float(raw_temp.replace("°C", "").replace("°", "").strip())
+            result.append(
+                {
+                    "sensor_key": uuid,
+                    "name": str(record.get("name") or uuid),
+                    "widgetgroup": str(record.get("widgetgroup") or ""),
+                    "temperature": temp,
+                }
+            )
+        return result
 
     def _normalize_compose(self, response: Any) -> list[dict[str, Any]]:
         """Normalize Docker/Compose containers and extract project relationships."""

--- a/custom_components/omv/manifest.json
+++ b/custom_components/omv/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/slybase/homeassistant-openmediavault/issues",
     "requirements": [],
-    "version": "2.3.0"
+    "version": "2.4.0"
 }

--- a/custom_components/omv/sensor.py
+++ b/custom_components/omv/sensor.py
@@ -17,6 +17,7 @@ from .entity import (
     get_container_device_info,
     get_disk_device_info,
     get_filesystem_device_info,
+    get_hub_device_info,
     get_storage_device_info,
 )
 from .sensor_types import (
@@ -41,6 +42,7 @@ from .sensor_types import (
     NETWORK_TX_SENSOR,
     RAID_SENSOR,
     SYSTEM_SENSORS,
+    TEMPMON_SENSORS,
     ZFS_POOL_SENSOR,
     OMVSensorDescription,
 )
@@ -468,6 +470,22 @@ async def async_setup_entry(
                     description,
                     item_key=item_key,
                     device_info=get_storage_device_info(coordinator, item),
+                )
+            )
+
+    for description in TEMPMON_SENSORS:
+        for sensor in coordinator.data.get("tempmon", []):
+            if not isinstance(sensor, dict):
+                continue
+            item_key = str(sensor.get("sensor_key") or "")
+            if not item_key or not _should_add_description(description, sensor):
+                continue
+            entities.append(
+                OMVSensor(
+                    coordinator,
+                    description,
+                    item_key=item_key,
+                    device_info=get_hub_device_info(coordinator),
                 )
             )
 

--- a/custom_components/omv/sensor_types.py
+++ b/custom_components/omv/sensor_types.py
@@ -644,3 +644,20 @@ ZFS_POOL_SENSOR = OMVSensorDescription(
         "capacity": data.get("capacity"),
     },
 )
+
+TEMPMON_SENSORS: tuple[OMVSensorDescription, ...] = (
+    OMVSensorDescription(
+        key="tempmon_temperature",
+        translation_key="tempmon_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        icon="mdi:thermometer",
+        state_class=SensorStateClass.MEASUREMENT,
+        data_path="tempmon",
+        is_collection=True,
+        collection_key="sensor_key",
+        name_key="name",
+        value_fn=lambda data: data.get("temperature"),
+        extra_attrs_fn=lambda data: {"group": data.get("widgetgroup") or None},
+    ),
+)

--- a/custom_components/omv/strings.json
+++ b/custom_components/omv/strings.json
@@ -146,6 +146,9 @@
             },
             "zfs_pool": {
                 "name": "{resource} ZFS pool"
+            },
+            "tempmon_temperature": {
+                "name": "{resource} temperature"
             }
         },
         "binary_sensor": {

--- a/custom_components/omv/translations/en.json
+++ b/custom_components/omv/translations/en.json
@@ -155,6 +155,9 @@
       },
       "disk_smart_status": {
         "name": "SMART Status"
+      },
+      "tempmon_temperature": {
+        "name": "{resource} temperature"
       }
     },
     "binary_sensor": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -22,7 +22,7 @@ from custom_components.omv.const import (
     DOMAIN,
 )
 from custom_components.omv.coordinator import OMVDataUpdateCoordinator
-from custom_components.omv.exceptions import OMVConnectionError
+from custom_components.omv.exceptions import OMVApiError, OMVConnectionError
 
 
 @pytest.mark.asyncio
@@ -155,6 +155,7 @@ async def test_coordinator_fetches_expected_data(hass, config_entry) -> None:
                 ]
             },
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
             ("zfs", "listPools"): [{"name": "tank", "state": "ONLINE"}],
             ("Apt", "getUpgradedList"): {
                 "total": 1,
@@ -271,6 +272,7 @@ async def test_coordinator_uses_mdmgmt_inventory_for_unmounted_md_arrays(hass, c
             ("Compose", "getVolumesBg"): [],
             ("zfs", "listPools"): [],
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
         }
         return responses[(service, method)]
 
@@ -782,6 +784,7 @@ async def test_coordinator_uses_legacy_smart_method_for_omv6(hass, config_entry)
             ("compose", "getFileList"): {"data": []},
             ("Compose", "getVolumesBg"): {"data": []},
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
             ("zfs", "listPools"): [],
         }
         return responses[(service, method)]
@@ -823,6 +826,7 @@ async def test_coordinator_falls_back_when_smart_get_list_bg_returns_task_id(has
             ("compose", "getFileList"): {"data": []},
             ("Compose", "getVolumesBg"): {"data": []},
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
             ("zfs", "listPools"): [],
         }
         return responses[(service, method)]
@@ -1147,6 +1151,7 @@ async def test_coordinator_maps_omv8_style_zfs_pool_to_disk(hass, config_entry) 
             ("compose", "getFileList"): {"data": []},
             ("Compose", "getVolumesBg"): {"data": []},
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
             ("zfs", "listPools"): {
                 "data": [
                     {
@@ -1224,6 +1229,7 @@ async def test_coordinator_creates_synthetic_md_devices_and_maps_zfs(hass, confi
             ("compose", "getFileList"): {"data": []},
             ("Compose", "getVolumesBg"): {"data": []},
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
             ("zfs", "listPools"): [
                 {
                     "name": "bigdata",
@@ -1500,6 +1506,7 @@ async def test_cpu_temp_zero_is_filtered_to_none(hass, config_entry) -> None:
             ("compose", "getFileList"): {"data": []},
             ("Compose", "getVolumesBg"): {"data": []},
             ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {"data": [], "total": 0},
             ("zfs", "listPools"): [],
         }
         return responses[(service, method)]
@@ -1904,3 +1911,153 @@ async def test_augment_disks_does_not_add_duplicate_when_dev_prefix_present(hass
     assert len(md_entries) == 1, (
         f"Expected 1 md0 disk entry, got {len(md_entries)}: {[d['disk_key'] for d in md_entries]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_tempmon_sensors_normalized(hass, config_entry) -> None:
+    """Test that TempMon.getSensorsList records are normalized into coordinator data."""
+    config_entry.add_to_hass(hass)
+    api = Mock()
+    api.base_url = "http://192.0.2.10:80"
+
+    async def async_call(service, method, params=None, **kwargs):
+        responses = {
+            ("System", "getInformation"): {"hostname": "nas", "version": "8.1.2-1"},
+            ("CpuTemp", "get"): {"cputemp": 55.0},
+            ("FileSystemMgmt", "enumerateFilesystems"): [],
+            ("Services", "getStatus"): [],
+            ("Network", "enumerateDevices"): [],
+            ("DiskMgmt", "enumerateDevices"): [],
+            ("Smart", "getListBg"): [],
+            ("Smart", "getList"): {"data": [], "total": 0},
+            ("compose", "getContainerList"): {"data": []},
+            ("compose", "getFileList"): {"data": []},
+            ("Compose", "getVolumesBg"): {"data": []},
+            ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {
+                "data": [
+                    {
+                        "uuid": "uuid-1",
+                        "name": "CPU Temp",
+                        "scriptpath": "/usr/local/bin/cpu-temp",
+                        "divisor": 1000,
+                        "widgetgroup": "CPU",
+                        "currenttemp": "26.8 °C",
+                    },
+                    {
+                        "uuid": "uuid-2",
+                        "name": "NVMe Temp",
+                        "scriptpath": "/usr/local/bin/nvme-temp",
+                        "divisor": 1,
+                        "widgetgroup": "",
+                        "currenttemp": "38.0 °C",
+                    },
+                ],
+                "total": 2,
+            },
+            ("zfs", "listPools"): [],
+        }
+        return responses[(service, method)]
+
+    api.async_call = AsyncMock(side_effect=async_call)
+    coordinator = OMVDataUpdateCoordinator(hass, config_entry, api, scan_interval=60)
+    await coordinator.async_init({"hostname": "nas", "version": "8.1.2-1"})
+
+    data = await coordinator._async_update_data()
+
+    sensors = data["tempmon"]
+    assert len(sensors) == 2
+
+    cpu = next(s for s in sensors if s["name"] == "CPU Temp")
+    assert cpu["sensor_key"] == "uuid-1"
+    assert cpu["temperature"] == 26.8
+    assert cpu["widgetgroup"] == "CPU"
+
+    nvme = next(s for s in sensors if s["name"] == "NVMe Temp")
+    assert nvme["sensor_key"] == "uuid-2"
+    assert nvme["temperature"] == 38.0
+    assert nvme["widgetgroup"] == ""
+
+
+@pytest.mark.asyncio
+async def test_tempmon_absent_when_plugin_not_installed(hass, config_entry) -> None:
+    """Test that coordinator.data['tempmon'] is empty when the plugin is not installed."""
+    config_entry.add_to_hass(hass)
+    api = Mock()
+    api.base_url = "http://192.0.2.10:80"
+
+    async def async_call(service, method, params=None, **kwargs):
+        if (service, method) == ("TempMon", "getSensorsList"):
+            raise OMVApiError("RPC service TempMon not found")
+        responses = {
+            ("System", "getInformation"): {"hostname": "nas", "version": "8.1.2-1"},
+            ("CpuTemp", "get"): {"cputemp": 55.0},
+            ("FileSystemMgmt", "enumerateFilesystems"): [],
+            ("Services", "getStatus"): [],
+            ("Network", "enumerateDevices"): [],
+            ("DiskMgmt", "enumerateDevices"): [],
+            ("Smart", "getListBg"): [],
+            ("Smart", "getList"): {"data": [], "total": 0},
+            ("compose", "getContainerList"): {"data": []},
+            ("compose", "getFileList"): {"data": []},
+            ("Compose", "getVolumesBg"): {"data": []},
+            ("Kvm", "getVmList"): {"data": []},
+            ("zfs", "listPools"): [],
+        }
+        return responses[(service, method)]
+
+    api.async_call = AsyncMock(side_effect=async_call)
+    coordinator = OMVDataUpdateCoordinator(hass, config_entry, api, scan_interval=60)
+    await coordinator.async_init({"hostname": "nas", "version": "8.1.2-1"})
+
+    data = await coordinator._async_update_data()
+
+    assert data["tempmon"] == []
+
+
+@pytest.mark.asyncio
+async def test_tempmon_script_error_returns_none_temperature(hass, config_entry) -> None:
+    """Test that a sensor with a failing script (currenttemp='-') gets temperature=None."""
+    config_entry.add_to_hass(hass)
+    api = Mock()
+    api.base_url = "http://192.0.2.10:80"
+
+    async def async_call(service, method, params=None, **kwargs):
+        responses = {
+            ("System", "getInformation"): {"hostname": "nas", "version": "8.1.2-1"},
+            ("CpuTemp", "get"): {"cputemp": 55.0},
+            ("FileSystemMgmt", "enumerateFilesystems"): [],
+            ("Services", "getStatus"): [],
+            ("Network", "enumerateDevices"): [],
+            ("DiskMgmt", "enumerateDevices"): [],
+            ("Smart", "getListBg"): [],
+            ("Smart", "getList"): {"data": [], "total": 0},
+            ("compose", "getContainerList"): {"data": []},
+            ("compose", "getFileList"): {"data": []},
+            ("Compose", "getVolumesBg"): {"data": []},
+            ("Kvm", "getVmList"): {"data": []},
+            ("TempMon", "getSensorsList"): {
+                "data": [
+                    {
+                        "uuid": "uuid-1",
+                        "name": "Broken Sensor",
+                        "scriptpath": "/usr/local/bin/broken",
+                        "divisor": 1,
+                        "widgetgroup": "",
+                        "currenttemp": "-",
+                    }
+                ],
+                "total": 1,
+            },
+            ("zfs", "listPools"): [],
+        }
+        return responses[(service, method)]
+
+    api.async_call = AsyncMock(side_effect=async_call)
+    coordinator = OMVDataUpdateCoordinator(hass, config_entry, api, scan_interval=60)
+    await coordinator.async_init({"hostname": "nas", "version": "8.1.2-1"})
+
+    data = await coordinator._async_update_data()
+
+    assert len(data["tempmon"]) == 1
+    assert data["tempmon"][0]["temperature"] is None


### PR DESCRIPTION
The changes introduce support for temperature sensors configured via the `openmediavault-tempmon` plugin, allowing accurate CPU temperature readings on ARM boards like the Rock5 ITX. This resolves the issue where the built-in CpuTemp plugin returns 0 °C by fetching the correct temperature from the specified sensor path. The version is updated to 2.4.0 to reflect these enhancements.
Fixes #36

