### PR TITLE
fix: SMART polling spin-down (#41) + ZFS pool unique-ID dedup (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - SMART polling no longer keeps disks spinning indefinitely: the per-cycle `Smart.getList`/`getAttributes` calls (which wake disks from standby) now run only on the configurable SMART interval instead of every scan interval, restoring OMV power-saving/spin-down behaviour (#41).
+- ZFS pool entities (status, scrub button, scrub-active, last-scrub/dataset/snapshot counts) no longer collide on duplicate unique IDs when a pool spans multiple disks; exactly one entity is now created per pool.
 
 ## [2.5.0] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.5.1] - 2026-06-17
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- New options-flow setting `SMART polling interval (seconds)` that decouples SMART reads from the scan interval (defaults to the scan interval). SMART records and attributes are cached between polls and re-applied to disks every cycle, so SMART/temperature entities stay populated while disks can spin down for power saving (#41).
+- New options-flow toggle `Disable SMART polling` that stops all SMART RPCs entirely; disks are then never woken by the integration, at the cost of SMART status/attribute/disk-temperature entities becoming unavailable (#41).
+
+### Fixed
+
+- SMART polling no longer keeps disks spinning indefinitely: the per-cycle `Smart.getList`/`getAttributes` calls (which wake disks from standby) now run only on the configurable SMART interval instead of every scan interval, restoring OMV power-saving/spin-down behaviour (#41).
+
 ## [2.5.0] - 2026-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The config flow asks for:
 After setup, the options flow lets you adjust:
 
 - The scan interval
-- Whether SMART polling should be disabled
-- Virtual passthrough mode for hypervisor-backed setups (e.g. Proxmox) — disables SMART polling and temperature entities automatically
+- The SMART polling interval — how often SMART data (status, attributes, disk temperature) is read. Reading SMART wakes disks from standby, so a larger interval lets disks spin down for power saving. Defaults to the scan interval.
+- Whether SMART polling is disabled entirely — disks are then never woken by the integration, but SMART status, SMART attributes, and disk temperature entities become unavailable
 - Which disks, filesystems, network interfaces, services, RAIDs, ZFS pools, Compose projects, and containers are monitored — resources not selected simply disappear from Home Assistant
 
 ## Entities

--- a/custom_components/omv/binary_sensor.py
+++ b/custom_components/omv/binary_sensor.py
@@ -162,12 +162,16 @@ async def async_setup_entry(
             continue
         entities.append(OMVBinarySensor(coordinator, RSYNC_JOB_ENABLED_BINARY_SENSOR, item_key=item_key))
 
+    # A pool spanning multiple disks appears once per disk in the zfs data;
+    # de-duplicate by pool name so only one scrub-active sensor is created.
+    seen_pools: set[str] = set()
     for pool in coordinator.data.get("zfs", []):
         if not isinstance(pool, dict):
             continue
         item_key = str(pool.get("name") or "")
-        if not item_key:
+        if not item_key or item_key in seen_pools:
             continue
+        seen_pools.add(item_key)
         entities.append(
             OMVBinarySensor(
                 coordinator,

--- a/custom_components/omv/button.py
+++ b/custom_components/omv/button.py
@@ -188,9 +188,16 @@ async def async_setup_entry(
             continue
         entities.append(OMVCronRunButton(coordinator, job))
 
+    # A pool spanning multiple disks appears once per disk in the zfs data;
+    # de-duplicate by pool name so only one scrub button is created.
+    seen_pools: set[str] = set()
     for pool in coordinator.data.get("zfs", []):
-        if not isinstance(pool, dict) or not str(pool.get("name") or ""):
+        if not isinstance(pool, dict):
             continue
+        pool_name = str(pool.get("name") or "")
+        if not pool_name or pool_name in seen_pools:
+            continue
+        seen_pools.add(pool_name)
         entities.append(OMVZfsScrubButton(coordinator, pool))
 
     for iface in coordinator.data.get("network", []):

--- a/custom_components/omv/config_flow.py
+++ b/custom_components/omv/config_flow.py
@@ -33,6 +33,8 @@ from .const import (
     CONF_SELECTED_SERVICES,
     CONF_SELECTED_VMS,
     CONF_SELECTED_ZFS_POOLS,
+    CONF_SMART_INTERVAL,
+    CONF_SMART_POLLING_DISABLED,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SSL,
@@ -216,6 +218,17 @@ class OMVOptionsFlow(OptionsFlow):
                 vol.Optional(
                     CONF_REBOOT_REPAIR_DISABLED,
                     default=self._entry.options.get(CONF_REBOOT_REPAIR_DISABLED, False),
+                ): bool,
+                vol.Optional(
+                    CONF_SMART_INTERVAL,
+                    default=self._entry.options.get(
+                        CONF_SMART_INTERVAL,
+                        self._entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    ),
+                ): vol.All(int, vol.Range(min=10, max=86400)),
+                vol.Optional(
+                    CONF_SMART_POLLING_DISABLED,
+                    default=self._entry.options.get(CONF_SMART_POLLING_DISABLED, False),
                 ): bool,
                 vol.Optional(
                     CONF_SELECTED_DISKS,

--- a/custom_components/omv/const.py
+++ b/custom_components/omv/const.py
@@ -21,6 +21,10 @@ DEFAULT_VERIFY_SSL = True
 # Optionsschlüssel für auswählbare Ressourcen
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_REBOOT_REPAIR_DISABLED = "reboot_repair_disabled"
+# SMART polling controls (Issue #41) — decouple SMART from the scan interval so
+# disks can spin down. CONF_SMART_INTERVAL defaults to the scan interval.
+CONF_SMART_INTERVAL = "smart_interval"
+CONF_SMART_POLLING_DISABLED = "smart_polling_disabled"
 CONF_SELECTED_DISKS = "selected_disks"
 CONF_SELECTED_FILESYSTEMS = "selected_filesystems"
 CONF_SELECTED_SERVICES = "selected_services"

--- a/custom_components/omv/coordinator.py
+++ b/custom_components/omv/coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -15,6 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    CONF_SCAN_INTERVAL,
     CONF_SELECTED_COMPOSE_PROJECTS,
     CONF_SELECTED_CONTAINERS,
     CONF_SELECTED_CRON_JOBS,
@@ -25,6 +27,8 @@ from .const import (
     CONF_SELECTED_SERVICES,
     CONF_SELECTED_VMS,
     CONF_SELECTED_ZFS_POOLS,
+    CONF_SMART_INTERVAL,
+    CONF_SMART_POLLING_DISABLED,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -100,6 +104,13 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # (e.g. NVMe or other non-ATA disks that return HTTP 500). Populated on
         # first failure; skipped on all subsequent polls to avoid log spam.
         self._smart_no_attributes: set[str] = set()
+        # SMART cache (Issue #41): SMART RPCs wake disks from standby, so they
+        # run only every CONF_SMART_INTERVAL seconds. The cached records and
+        # per-canonical attributes are re-applied to freshly enumerated disks on
+        # every cycle so SMART/temperature entities stay populated in between.
+        self._smart_records_cache: list[dict[str, Any]] = []
+        self._smart_attributes_cache: dict[str, dict[str, Any]] = {}
+        self._smart_last_poll: float | None = None
 
     async def async_init(self, system_info: dict[str, Any]) -> None:
         """Initialize version metadata from the initial connect response."""
@@ -381,7 +392,7 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     pool["dataset_count"] = dataset_counts.get(pool_name, 0)
                     pool["snapshot_count"] = snapshot_counts.get(pool_name, 0)
 
-            smart_records = await self._async_get_smart(disks)
+            smart_records = await self._async_collect_smart(disks)
 
             gpu = await self._async_get_gpu_info()
 
@@ -737,8 +748,69 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return hwinfo
 
-    async def _async_get_smart(self, disks: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Fetch SMART information and merge relevant fields into disks."""
+    async def _async_collect_smart(self, disks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Refresh SMART data on its own interval and apply it to the disks.
+
+        SMART RPCs run ``smartctl``, which wakes disks from standby; polling them
+        every scan interval prevents OMV's disk spin-down (Issue #41). They are
+        therefore fetched at most once per ``CONF_SMART_INTERVAL`` seconds and
+        cached, while the cached records/attributes are re-applied to the freshly
+        enumerated disks on every cycle so SMART and temperature entities stay
+        populated in between. When ``CONF_SMART_POLLING_DISABLED`` is set, no
+        SMART RPC is ever issued and the disks keep no SMART/temperature fields.
+
+        Args:
+            disks: Normalized disk records for the current cycle (mutated in place).
+
+        Returns:
+            The cached SMART records (empty list when polling is disabled).
+        """
+        options = self.config_entry.options
+        if options.get(CONF_SMART_POLLING_DISABLED, False):
+            self._smart_records_cache = []
+            self._smart_attributes_cache = {}
+            _LOGGER.debug("SMART polling disabled via options; skipping fetch")
+            return []
+
+        interval = options.get(
+            CONF_SMART_INTERVAL,
+            options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+        )
+        now = time.monotonic()
+        if self._smart_last_poll is None or (now - self._smart_last_poll) >= interval:
+            (
+                self._smart_records_cache,
+                self._smart_attributes_cache,
+            ) = await self._async_fetch_smart(disks)
+            self._smart_last_poll = now
+            _LOGGER.debug("SMART data refreshed (interval=%ss)", interval)
+        else:
+            _LOGGER.debug(
+                "Using cached SMART data (%.0fs since last poll, interval=%ss)",
+                now - self._smart_last_poll,
+                interval,
+            )
+
+        self._apply_smart_to_disks(disks, self._smart_records_cache, self._smart_attributes_cache)
+        return self._smart_records_cache
+
+    async def _async_fetch_smart(
+        self, disks: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+        """Fetch SMART records and per-disk attributes via RPC.
+
+        This issues the live SMART RPCs (``getListBg``/``getList`` and per-disk
+        ``getAttributes``), which spin disks up — call it only on the SMART poll
+        cadence. It does not mutate the disk records.
+
+        Args:
+            disks: Normalized disk records used to decide which canonical device
+                files to query for attributes.
+
+        Returns:
+            Tuple of ``(smart_records, attributes_by_canonical)`` where the second
+            element maps a canonical device file to its ``{attrname: rawvalue}``.
+        """
         method = "getListBg" if self.omv_version >= 7 else "getList"
         params = {"start": 0, "limit": 100}
         # Use _fetch_optional so HTTP 500 / transient errors don't abort the full update
@@ -753,29 +825,9 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             response = await self._fetch_optional("Smart", "getList", params)
 
         smart_records = self._records_from_response(response)
-        smart_by_key: dict[str, dict[str, Any]] = {}
-        for record in smart_records:
-            for key in self._disk_record_keys(record):
-                smart_by_key[key] = record
 
+        attributes_by_canonical: dict[str, dict[str, Any]] = {}
         for disk in disks:
-            smart_record = None
-            for key in self._disk_record_keys(disk):
-                smart_record = smart_by_key.get(key)
-                if smart_record is not None:
-                    break
-
-            if smart_record is not None and not disk.get("is_virtual"):
-                smart_temp = self._coerce_optional_float(smart_record.get("temperature"))
-                if smart_temp:
-                    disk["temperature"] = smart_temp
-                disk["overallstatus"] = str(smart_record.get("overallstatus", disk.get("overallstatus", "unknown")))
-                disk["smart_details"] = {
-                    key: value
-                    for key, value in smart_record.items()
-                    if key not in {"devicename", "devicefile", "canonicaldevicefile"}
-                }
-
             canonical = str(disk.get("canonicaldevicefile") or "")
             if (
                 not canonical
@@ -821,12 +873,57 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raw_value = attribute.get("rawvalue", "unknown")
                 if isinstance(raw_value, str) and " " in raw_value:
                     raw_value = raw_value.split(" ", 1)[0]
-                disk[str(attrname)] = raw_value
                 smart_attributes[str(attrname)] = raw_value
             if smart_attributes:
-                disk["smart_attributes"] = smart_attributes
+                attributes_by_canonical[canonical] = smart_attributes
 
-        return smart_records
+        return smart_records, attributes_by_canonical
+
+    def _apply_smart_to_disks(
+        self,
+        disks: list[dict[str, Any]],
+        smart_records: list[dict[str, Any]],
+        attributes_by_canonical: dict[str, dict[str, Any]],
+    ) -> None:
+        """Merge (cached or freshly fetched) SMART data into disk records.
+
+        Pure with respect to the API — performs no RPC, so it is safe to call on
+        every cycle to keep SMART/temperature entities populated between polls.
+
+        Args:
+            disks: Normalized disk records to enrich in place.
+            smart_records: Bulk SMART records (overall status, temperature).
+            attributes_by_canonical: Per-canonical ``{attrname: rawvalue}`` maps.
+        """
+        smart_by_key: dict[str, dict[str, Any]] = {}
+        for record in smart_records:
+            for key in self._disk_record_keys(record):
+                smart_by_key[key] = record
+
+        for disk in disks:
+            smart_record = None
+            for key in self._disk_record_keys(disk):
+                smart_record = smart_by_key.get(key)
+                if smart_record is not None:
+                    break
+
+            if smart_record is not None and not disk.get("is_virtual"):
+                smart_temp = self._coerce_optional_float(smart_record.get("temperature"))
+                if smart_temp:
+                    disk["temperature"] = smart_temp
+                disk["overallstatus"] = str(smart_record.get("overallstatus", disk.get("overallstatus", "unknown")))
+                disk["smart_details"] = {
+                    key: value
+                    for key, value in smart_record.items()
+                    if key not in {"devicename", "devicefile", "canonicaldevicefile"}
+                }
+
+            canonical = str(disk.get("canonicaldevicefile") or "")
+            smart_attributes = attributes_by_canonical.get(canonical)
+            if smart_attributes:
+                for attrname, raw_value in smart_attributes.items():
+                    disk[attrname] = raw_value
+                disk["smart_attributes"] = dict(smart_attributes)
 
     async def _async_get_gpu_info(self) -> dict[str, Any]:
         """Read Intel iGPU info from sysfs and apply spike filtering."""

--- a/custom_components/omv/manifest.json
+++ b/custom_components/omv/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/slybase/homeassistant-openmediavault/issues",
     "requirements": [],
-    "version": "2.5.0"
+    "version": "2.5.1"
 }

--- a/custom_components/omv/sensor.py
+++ b/custom_components/omv/sensor.py
@@ -513,12 +513,17 @@ async def async_setup_entry(
         items = coordinator.data.get(description.data_path, [])
         if not isinstance(items, list):
             continue
+        # A ZFS pool spanning multiple disks yields one record per disk in
+        # coordinator.data["zfs"], all sharing the same pool name. De-duplicate
+        # by item_key so exactly one entity is created per pool (first wins).
+        seen_keys: set[str] = set()
         for item in items:
             if not isinstance(item, dict):
                 continue
             item_key = str(item.get(description.collection_key or "") or "")
-            if not item_key or not _should_add_description(description, item):
+            if not item_key or item_key in seen_keys or not _should_add_description(description, item):
                 continue
+            seen_keys.add(item_key)
             entities.append(
                 OMVSensor(
                     coordinator,

--- a/custom_components/omv/strings.json
+++ b/custom_components/omv/strings.json
@@ -25,6 +25,8 @@
                 "data": {
                     "scan_interval": "Scan interval (seconds)",
                     "reboot_repair_disabled": "Disable reboot required notification",
+                    "smart_interval": "SMART polling interval (seconds)",
+                    "smart_polling_disabled": "Disable SMART polling",
                     "selected_disks": "Selected disks",
                     "selected_filesystems": "Selected filesystems",
                     "selected_services": "Selected services",
@@ -38,6 +40,8 @@
                 },
                 "data_description": {
                     "reboot_repair_disabled": "When enabled, the Home Assistant repair notification for a pending OMV reboot is suppressed. Useful when a reboot cannot be performed immediately, e.g. because VMs are running on the NAS.",
+                    "smart_interval": "How often SMART data (status, attributes, disk temperature) is read. Reading SMART wakes disks from standby, so a larger value lets disks spin down for power saving. Defaults to the scan interval.",
+                    "smart_polling_disabled": "When enabled, SMART is never polled. Disks are never woken by this integration, but SMART status, SMART attributes and disk temperature entities become unavailable.",
                     "selected_cron_jobs": "Creates a button for each selected user-defined cron job. Warning: pressing such a button runs the job's arbitrary shell command on the NAS. Default: none."
                 }
             }

--- a/custom_components/omv/translations/de.json
+++ b/custom_components/omv/translations/de.json
@@ -25,6 +25,8 @@
         "data": {
           "scan_interval": "Abfrageintervall (Sekunden)",
           "reboot_repair_disabled": "Neustart-Benachrichtigung deaktivieren",
+          "smart_interval": "SMART-Abfrageintervall (Sekunden)",
+          "smart_polling_disabled": "SMART-Abfrage deaktivieren",
           "selected_disks": "Ausgewählte Festplatten",
           "selected_filesystems": "Ausgewählte Dateisysteme",
           "selected_services": "Ausgewählte Dienste",
@@ -38,6 +40,8 @@
         },
         "data_description": {
           "reboot_repair_disabled": "Wenn aktiviert, wird die Home Assistant Repair-Benachrichtigung für einen ausstehenden OMV-Neustart unterdrückt. Nützlich, wenn ein Neustart nicht sofort möglich ist, z. B. weil VMs auf dem NAS laufen.",
+          "smart_interval": "Wie oft SMART-Daten (Status, Attribute, Festplattentemperatur) gelesen werden. Das Lesen von SMART weckt Festplatten aus dem Standby, daher lässt ein größerer Wert die Festplatten zum Energiesparen herunterfahren. Standard: das Abfrageintervall.",
+          "smart_polling_disabled": "Wenn aktiviert, wird SMART nie abgefragt. Festplatten werden von dieser Integration nicht geweckt, aber die Entitäten für SMART-Status, SMART-Attribute und Festplattentemperatur werden nicht verfügbar.",
           "selected_cron_jobs": "Erstellt einen Button für jeden ausgewählten benutzerdefinierten Cron-Job. Achtung: Das Drücken eines solchen Buttons führt das beliebige Shell-Kommando des Jobs auf dem NAS aus. Standard: keine."
         }
       }

--- a/custom_components/omv/translations/en.json
+++ b/custom_components/omv/translations/en.json
@@ -25,6 +25,8 @@
         "data": {
           "scan_interval": "Scan interval (seconds)",
           "reboot_repair_disabled": "Disable reboot required notification",
+          "smart_interval": "SMART polling interval (seconds)",
+          "smart_polling_disabled": "Disable SMART polling",
           "selected_disks": "Selected disks",
           "selected_filesystems": "Selected filesystems",
           "selected_services": "Selected services",
@@ -38,6 +40,8 @@
         },
         "data_description": {
           "reboot_repair_disabled": "When enabled, the Home Assistant repair notification for a pending OMV reboot is suppressed. Useful when a reboot cannot be performed immediately, e.g. because VMs are running on the NAS.",
+          "smart_interval": "How often SMART data (status, attributes, disk temperature) is read. Reading SMART wakes disks from standby, so a larger value lets disks spin down for power saving. Defaults to the scan interval.",
+          "smart_polling_disabled": "When enabled, SMART is never polled. Disks are never woken by this integration, but SMART status, SMART attributes and disk temperature entities become unavailable.",
           "selected_cron_jobs": "Creates a button for each selected user-defined cron job. Warning: pressing such a button runs the job's arbitrary shell command on the NAS. Default: none."
         }
       }

--- a/custom_components/omv/translations/nl.json
+++ b/custom_components/omv/translations/nl.json
@@ -24,6 +24,8 @@
       "init": {
         "data": {
           "scan_interval": "Scaninterval (seconden)",
+          "smart_interval": "SMART-pollinginterval (seconden)",
+          "smart_polling_disabled": "SMART-polling uitschakelen",
           "selected_disks": "Geselecteerde schijven",
           "selected_filesystems": "Geselecteerde bestandssystemen",
           "selected_services": "Geselecteerde services",
@@ -36,6 +38,8 @@
           "selected_cron_jobs": "Cron-taken met triggerknop"
         },
         "data_description": {
+          "smart_interval": "Hoe vaak SMART-gegevens (status, attributen, schijftemperatuur) worden gelezen. Het lezen van SMART haalt schijven uit stand-by, dus een hogere waarde laat schijven uitschakelen om energie te besparen. Standaard: het scaninterval.",
+          "smart_polling_disabled": "Indien ingeschakeld wordt SMART nooit gepolld. Schijven worden door deze integratie niet gewekt, maar de entiteiten voor SMART-status, SMART-attributen en schijftemperatuur worden niet beschikbaar.",
           "selected_cron_jobs": "Maakt een knop voor elke geselecteerde door de gebruiker gedefinieerde cron-taak. Waarschuwing: het indrukken van zo'n knop voert het willekeurige shell-commando van de taak uit op de NAS. Standaard: geen."
         }
       }

--- a/custom_components/omv/translations/pt_BR.json
+++ b/custom_components/omv/translations/pt_BR.json
@@ -24,6 +24,8 @@
       "init": {
         "data": {
           "scan_interval": "Intervalo de varredura (segundos)",
+          "smart_interval": "Intervalo de consulta SMART (segundos)",
+          "smart_polling_disabled": "Desativar consulta SMART",
           "selected_disks": "Discos selecionados",
           "selected_filesystems": "Sistemas de arquivos selecionados",
           "selected_services": "Serviços selecionados",
@@ -36,6 +38,8 @@
           "selected_cron_jobs": "Tarefas cron com botão de acionamento"
         },
         "data_description": {
+          "smart_interval": "Com que frequência os dados SMART (status, atributos, temperatura do disco) são lidos. Ler SMART desperta os discos do modo de espera, portanto um valor maior permite que os discos desliguem para economizar energia. Padrão: o intervalo de varredura.",
+          "smart_polling_disabled": "Quando ativado, o SMART nunca é consultado. Os discos não são despertados por esta integração, mas as entidades de status SMART, atributos SMART e temperatura do disco ficam indisponíveis.",
           "selected_cron_jobs": "Cria um botão para cada tarefa cron definida pelo usuário selecionada. Aviso: pressionar esse botão executa o comando shell arbitrário da tarefa no NAS. Padrão: nenhuma."
         }
       }

--- a/custom_components/omv/translations/sv_SE.json
+++ b/custom_components/omv/translations/sv_SE.json
@@ -24,6 +24,8 @@
       "init": {
         "data": {
           "scan_interval": "Skanningsintervall (sekunder)",
+          "smart_interval": "SMART-pollningsintervall (sekunder)",
+          "smart_polling_disabled": "Inaktivera SMART-pollning",
           "selected_disks": "Valda diskar",
           "selected_filesystems": "Valda filsystem",
           "selected_services": "Valda tjänster",
@@ -36,6 +38,8 @@
           "selected_cron_jobs": "Cron-jobb med utlösarknapp"
         },
         "data_description": {
+          "smart_interval": "Hur ofta SMART-data (status, attribut, disktemperatur) läses. Att läsa SMART väcker diskar ur vänteläge, så ett större värde låter diskar stängas av för att spara ström. Standard: skanningsintervallet.",
+          "smart_polling_disabled": "När aktiverat pollas SMART aldrig. Diskar väcks aldrig av denna integration, men entiteterna för SMART-status, SMART-attribut och disktemperatur blir otillgängliga.",
           "selected_cron_jobs": "Skapar en knapp för varje valt användardefinierat cron-jobb. Varning: när knappen trycks körs jobbets godtyckliga skalkommando på NAS:en. Standard: inga."
         }
       }

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -246,3 +246,22 @@ async def test_zfs_pool_scrub_active_setup_and_expected_ids(coordinator, config_
     assert any(entity.unique_id.endswith("zfs_pool_scrub_active-tank") for entity in added)
     entry_id = coordinator.config_entry.entry_id
     assert f"{entry_id}-zfs_pool_scrub_active-tank" in get_expected_binary_sensor_unique_ids(coordinator)
+
+
+@pytest.mark.asyncio
+async def test_zfs_scrub_active_dedupes_across_disks(coordinator, config_entry) -> None:
+    """A pool spanning multiple disks gets exactly one scrub-active sensor."""
+    pool_a = coordinator.data["zfs"][0]
+    pool_b = {**pool_a, "disk_key": "sdb"}  # same name "tank", different disk
+    coordinator.data = {**coordinator.data, "zfs": [pool_a, pool_b]}
+
+    added: list = []
+
+    def add_entities(entities):
+        added.extend(entities)
+
+    await async_setup_entry(coordinator.hass, config_entry, add_entities)
+
+    unique_ids = [entity.unique_id for entity in added]
+    assert len(unique_ids) == len(set(unique_ids))
+    assert sum(uid.endswith("zfs_pool_scrub_active-tank") for uid in unique_ids) == 1

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -654,3 +654,22 @@ def test_get_expected_button_unique_ids_includes_standby_and_wol(coordinator, co
     coordinator.data["network"][0]["wol"] = True
     unique_ids = get_expected_button_unique_ids(config_entry, coordinator)
     assert f"{config_entry.entry_id}-wol-net-1" in unique_ids
+
+
+@pytest.mark.asyncio
+async def test_zfs_scrub_button_dedupes_across_disks(coordinator, config_entry) -> None:
+    """A pool spanning multiple disks gets exactly one scrub button."""
+    pool_a = coordinator.data["zfs"][0]
+    pool_b = {**pool_a, "disk_key": "sdb"}  # same name "tank", different disk
+    coordinator.data = {**coordinator.data, "zfs": [pool_a, pool_b]}
+
+    added: list = []
+
+    def add_entities(entities):
+        added.extend(entities)
+
+    await async_setup_entry(coordinator.hass, config_entry, add_entities)
+
+    unique_ids = [entity.unique_id for entity in added]
+    assert len(unique_ids) == len(set(unique_ids))
+    assert sum(uid.endswith("zfs_scrub-tank") for uid in unique_ids) == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,6 +28,8 @@ from custom_components.omv.const import (
     CONF_SELECTED_RAIDS,
     CONF_SELECTED_SERVICES,
     CONF_SELECTED_ZFS_POOLS,
+    CONF_SMART_INTERVAL,
+    CONF_SMART_POLLING_DISABLED,
     DOMAIN,
 )
 from custom_components.omv.exceptions import OMVAuthError
@@ -199,6 +201,47 @@ async def test_options_flow_uses_live_inventory_and_defaults_to_all(hass, config
     disk_marker = _field_marker(result["data_schema"], CONF_SELECTED_DISKS)
     disk_selector = result["data_schema"].schema[disk_marker]
     assert _selector_values(disk_selector) == ["sda", "sdb"]
+
+
+@pytest.mark.asyncio
+async def test_options_flow_exposes_smart_polling_controls(hass, config_entry) -> None:
+    """The options flow exposes the SMART interval and disable toggle (#41)."""
+    config_entry.runtime_data = type(
+        "RuntimeCoordinator",
+        (),
+        {"get_live_inventory": lambda self=None: {}},
+    )()
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    defaults = result["data_schema"]({})
+
+    # SMART interval defaults to the scan interval; the disable toggle defaults to off.
+    assert defaults[CONF_SMART_INTERVAL] == defaults[CONF_SCAN_INTERVAL]
+    assert defaults[CONF_SMART_POLLING_DISABLED] is False
+
+
+@pytest.mark.asyncio
+async def test_options_flow_honors_stored_smart_polling_controls(hass) -> None:
+    """A stored SMART interval/disable toggle is reflected as the schema default (#41)."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OMV (nas)",
+        data=USER_INPUT,
+        options={CONF_SMART_INTERVAL: 3600, CONF_SMART_POLLING_DISABLED: True},
+    )
+    config_entry.runtime_data = type(
+        "RuntimeCoordinator",
+        (),
+        {"get_live_inventory": lambda self=None: {}},
+    )()
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    defaults = result["data_schema"]({})
+
+    assert defaults[CONF_SMART_INTERVAL] == 3600
+    assert defaults[CONF_SMART_POLLING_DISABLED] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -20,6 +20,8 @@ from custom_components.omv.const import (
     CONF_SELECTED_SERVICES,
     CONF_SELECTED_VMS,
     CONF_SELECTED_ZFS_POOLS,
+    CONF_SMART_INTERVAL,
+    CONF_SMART_POLLING_DISABLED,
     DOMAIN,
 )
 from custom_components.omv.coordinator import OMVDataUpdateCoordinator
@@ -1649,7 +1651,7 @@ async def test_smart_skips_getattributes_for_hotpluggable_disk(hass, config_entr
     )
     coordinator.omv_version = 7
 
-    await coordinator._async_get_smart(disks)
+    await coordinator._async_fetch_smart(disks)
 
     # getAttributes must NOT have been called for the hotpluggable disk
     for call in api.async_call.await_args_list:
@@ -1691,7 +1693,7 @@ async def test_smart_does_not_skip_getattributes_for_non_hotpluggable_disk(hass,
     api.async_call = AsyncMock(side_effect=async_call)
     coordinator.omv_version = 8
 
-    await coordinator._async_get_smart(disks)
+    await coordinator._async_fetch_smart(disks)
 
     assert any(
         len(call.args) >= 2 and call.args[0] == "Smart" and call.args[1] == "getAttributes"
@@ -1733,17 +1735,106 @@ async def test_smart_skips_getattributes_after_failure(hass, config_entry) -> No
     coordinator.omv_version = 8
 
     # First poll: getAttributes fails, device added to _smart_no_attributes
-    await coordinator._async_get_smart(disks)
+    await coordinator._async_fetch_smart(disks)
     assert "/dev/sda" in coordinator._smart_no_attributes
 
     api.async_call.reset_mock()
 
     # Second poll: getAttributes must NOT be called again
-    await coordinator._async_get_smart(disks)
+    await coordinator._async_fetch_smart(disks)
     for call in api.async_call.await_args_list:
         assert not (len(call.args) >= 2 and call.args[0] == "Smart" and call.args[1] == "getAttributes"), (
             "getAttributes was called again after a permanent failure"
         )
+
+
+@pytest.mark.asyncio
+async def test_smart_polling_disabled_skips_all_rpcs(hass, config_entry) -> None:
+    """With SMART polling disabled no Smart RPC runs and disks keep no SMART data (#41)."""
+    patched_entry = config_entry.__class__(
+        domain=config_entry.domain,
+        title=config_entry.title,
+        data=config_entry.data,
+        options={CONF_SMART_POLLING_DISABLED: True},
+    )
+    patched_entry.add_to_hass(hass)
+    api = Mock()
+    api.base_url = "http://192.0.2.10:80"
+    api.async_call = AsyncMock(return_value={"data": []})
+    coordinator = OMVDataUpdateCoordinator(hass, patched_entry, api, scan_interval=60)
+    coordinator.omv_version = 8
+
+    disks = [
+        {
+            "disk_key": "sda",
+            "devicename": "sda",
+            "canonicaldevicefile": "/dev/sda",
+            "devicefile": "/dev/sda",
+            "hotpluggable": False,
+            "overallstatus": "unknown",
+        }
+    ]
+
+    records = await coordinator._async_collect_smart(disks)
+
+    assert records == []
+    assert "temperature" not in disks[0]
+    for call in api.async_call.await_args_list:
+        assert call.args[0] != "Smart", "no SMART RPC should run when polling is disabled"
+
+
+@pytest.mark.asyncio
+async def test_smart_interval_caches_between_polls(hass, config_entry) -> None:
+    """SMART RPCs run once per interval; cached data is re-applied to disks in between (#41)."""
+    patched_entry = config_entry.__class__(
+        domain=config_entry.domain,
+        title=config_entry.title,
+        data=config_entry.data,
+        options={CONF_SMART_INTERVAL: 3600},
+    )
+    patched_entry.add_to_hass(hass)
+    api = Mock()
+    api.base_url = "http://192.0.2.10:80"
+
+    async def async_call(service, method, params=None, **kwargs):
+        if method == "getListBg":
+            return {"data": [{"devicename": "sda", "temperature": 35, "overallstatus": "PASSED"}]}
+        if method == "getAttributes":
+            return {"data": [{"attrname": "Raw_Read_Error_Rate", "rawvalue": "0"}]}
+        return []
+
+    api.async_call = AsyncMock(side_effect=async_call)
+    coordinator = OMVDataUpdateCoordinator(hass, patched_entry, api, scan_interval=60)
+    coordinator.omv_version = 8
+
+    def make_disks() -> list[dict]:
+        return [
+            {
+                "disk_key": "sda",
+                "devicename": "sda",
+                "canonicaldevicefile": "/dev/sda",
+                "devicefile": "/dev/sda",
+                "hotpluggable": False,
+                "overallstatus": "unknown",
+            }
+        ]
+
+    # First poll: live fetch populates the cache and the disk.
+    disks1 = make_disks()
+    await coordinator._async_collect_smart(disks1)
+    smart_calls_first = sum(1 for c in api.async_call.await_args_list if c.args[0] == "Smart")
+    assert smart_calls_first > 0
+    assert disks1[0]["temperature"] == 35
+
+    api.async_call.reset_mock()
+
+    # Second poll within the interval: no SMART RPC, cache still applied to fresh disks.
+    disks2 = make_disks()
+    await coordinator._async_collect_smart(disks2)
+    smart_calls_second = sum(1 for c in api.async_call.await_args_list if c.args[0] == "Smart")
+    assert smart_calls_second == 0
+    assert disks2[0]["temperature"] == 35
+    assert disks2[0]["smart_attributes"] == {"Raw_Read_Error_Rate": "0"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -577,3 +577,28 @@ async def test_expected_sensor_registry_state_includes_zfs_entities(coordinator)
     assert f"{entry_id}-zfs_pool_snapshot_count-tank" in unique_ids
     assert f"{entry_id}-zfs_dataset_used-tank/media" in unique_ids
     assert f"{entry_id}-zfs_dataset_used-tank/docs" in unique_ids
+
+
+@pytest.mark.asyncio
+async def test_zfs_pool_sensors_dedupe_across_disks(coordinator, config_entry) -> None:
+    """A pool spanning multiple disks yields one entity per pool sensor."""
+    pool_a = coordinator.data["zfs"][0]
+    pool_b = {**pool_a, "disk_key": "sdb"}  # same name "tank", different disk
+    coordinator.data = {**coordinator.data, "zfs": [pool_a, pool_b]}
+
+    added: list = []
+
+    def add_entities(entities):
+        added.extend(entities)
+
+    await async_setup_entry(coordinator.hass, config_entry, add_entities)
+
+    unique_ids = [entity.unique_id for entity in added]
+    assert len(unique_ids) == len(set(unique_ids))
+    for suffix in (
+        "zfs_pool-tank",
+        "zfs_pool_last_scrub-tank",
+        "zfs_pool_dataset_count-tank",
+        "zfs_pool_snapshot_count-tank",
+    ):
+        assert sum(uid.endswith(suffix) for uid in unique_ids) == 1, suffix


### PR DESCRIPTION
## Summary

Release **2.5.1**. Two bug fixes:

### SMART polling no longer prevents disk spin-down (#41)
SMART RPCs run `smartctl`, which wakes disks from standby. Running them every scan interval kept disks spinning indefinitely and defeated OMV's power-saving. The two options the README already advertised were never implemented — now they are:

- **`SMART polling interval (seconds)`** — decouples SMART from the scan interval (defaults to the scan interval). SMART records/attributes are cached between polls and re-applied to freshly enumerated disks every cycle, so SMART/temperature entities stay populated while disks can spin down.
- **`Disable SMART polling`** — skips all SMART RPCs entirely; disks are never woken (SMART/temperature entities become unavailable).

`_async_get_smart` was split into `_async_collect_smart` (cadence/cache), `_async_fetch_smart` (RPC) and `_apply_smart_to_disks` (pure apply). Options-flow fields + strings/translations (en/de/nl/pt_BR/sv_SE). Removed the outdated README "virtual passthrough" line.

### ZFS pool entity unique-ID de-duplication
ZFS pool entities (status, scrub button, scrub-active, last-scrub / dataset / snapshot counts) collided on duplicate unique IDs when a pool spanned multiple disks, so Home Assistant silently dropped the duplicates. Now exactly one entity set is created per pool.

## Testing
- `pytest tests` → **290 passed**
- `ruff check` → clean
- `mypy custom_components/omv` → no new errors (pre-existing only)
- **Live smoke test**: deployed to Home Assistant, OMV8 integration loads cleanly, new SMART options present, OMV entities report real states, no SMART/coordinator errors in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)