### PR TITLE
fix(ci): remove blocked Actions PR-approve step from auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,10 +16,9 @@ jobs:
       - uses: dependabot/fetch-metadata@v3
         id: metadata
 
-      - name: Approve and enable auto-merge for patch/minor updates
+      - name: Enable auto-merge for patch/minor updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Dependabot auto-merge workflow was failing on every PR (#47, #48) with `GitHub Actions is not permitted to approve pull requests` — the org policy `can_approve_pull_request_reviews` is `false` and cannot be overridden at repo level.
- Removed the `gh pr review --approve` step. `main` has no branch protection requiring review approval, so `gh pr merge --auto --squash` alone is sufficient.
- Also enabled the repo setting `allow_auto_merge` (was `false`, blocking the `--auto` flag regardless of the approve step).

## Test plan
- [ ] Merge this PR
- [ ] Confirm the next Dependabot PR's `auto-merge` job succeeds and the PR auto-merges once checks pass