### PR TITLE
fix(security): harden container service input, logs, CI and diagnostics (v2.6.1)

### DIFF
--- a/.github/scripts/deploy-to-homeassistant.sh
+++ b/.github/scripts/deploy-to-homeassistant.sh
@@ -13,8 +13,16 @@
 #
 # Requirements on the pi:
 #   - SSH alias "pi" must be configured in ~/.ssh/config.
-#   - The user must have passwordless sudo for `cp`, `rm`, and `docker compose`
-#     (or for all commands via NOPASSWD: ALL).
+#   - The user must have passwordless sudo for `cp`, `rm`, `docker compose`
+#     and `docker inspect` on the fixed paths/service used below. Prefer a
+#     scoped sudoers entry over `NOPASSWD: ALL`, e.g. (adjust paths/user):
+#       timon ALL=(root) NOPASSWD: \
+#         /bin/cp -r /home/timon/homeassistant/tmp/omv /home/timon/homeassistant/hass/hass-config/custom_components/omv, \
+#         /bin/rm -rf /home/timon/homeassistant/hass/hass-config/custom_components/omv, \
+#         /usr/bin/docker compose restart hass, \
+#         /usr/bin/docker inspect * hass
+#     A compromised dev SSH key then only grants this narrow surface, not
+#     full root on the pi.
 #
 # Usage:
 #   bash .github/scripts/deploy-to-homeassistant.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         if: always()
         with:
           use_oidc: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+      - run: pip install pip-audit
+      - run: pip-audit
+        continue-on-error: true
 
   hacs:
     runs-on: ubuntu-latest
@@ -53,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: home-assistant/actions/hassfest@master
+      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/custom_components/omv/config_flow.py
+++ b/custom_components/omv/config_flow.py
@@ -210,14 +210,12 @@ class OMVConfigFlow(ConfigFlow, domain=DOMAIN):
             self._update_user_form_values(user_input)
             _LOGGER.debug(
                 "OMV config flow submit host=%r username=%r port=%s ssl=%s "
-                "verify_ssl=%s password_length=%d "
-                "password_has_outer_whitespace=%s",
+                "verify_ssl=%s password_has_outer_whitespace=%s",
                 user_input[CONF_HOST],
                 user_input[CONF_USERNAME],
                 user_input.get(CONF_PORT, DEFAULT_PORT),
                 user_input.get(CONF_SSL, DEFAULT_SSL),
                 user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-                len(user_input[CONF_PASSWORD]),
                 user_input[CONF_PASSWORD] != user_input[CONF_PASSWORD].strip(),
             )
             api = OMVAPI(

--- a/custom_components/omv/coordinator.py
+++ b/custom_components/omv/coordinator.py
@@ -246,7 +246,7 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "hostport2": "n/a",
         }
         response = await self.api.async_call("Kvm", "doCommand", params)
-        _LOGGER.debug("Kvm.doCommand params=%s response=%s", params, response)
+        _LOGGER.debug("Kvm.doCommand command=%s name=%s", params["command"], params["name"])
         return response
 
     async def async_execute_rsync_job(self, uuid: str) -> Any:

--- a/custom_components/omv/diagnostics.py
+++ b/custom_components/omv/diagnostics.py
@@ -18,6 +18,7 @@ TO_REDACT = {
     "gateway",
     "macaddress",
     "mac",
+    "hostname",
 }
 
 

--- a/custom_components/omv/manifest.json
+++ b/custom_components/omv/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/slybase/homeassistant-openmediavault/issues",
     "requirements": [],
-    "version": "2.6.0"
+    "version": "2.6.1"
 }

--- a/custom_components/omv/omv_api.py
+++ b/custom_components/omv/omv_api.py
@@ -61,7 +61,7 @@ class OMVAPI:
         """Create a session, authenticate and return system information."""
         _LOGGER.debug(
             "Starting OMV connect [%s] host=%r port=%s ssl=%s verify_ssl=%s "
-            "username=%r username_has_outer_whitespace=%s password_length=%d "
+            "username=%r username_has_outer_whitespace=%s "
             "password_has_outer_whitespace=%s",
             self._source,
             self._host,
@@ -70,7 +70,6 @@ class OMVAPI:
             self._verify_ssl,
             self._username,
             self._has_outer_whitespace(self._username),
-            len(self._password),
             self._has_outer_whitespace(self._password),
         )
         await self._async_ensure_session()

--- a/custom_components/omv/services.py
+++ b/custom_components/omv/services.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall, callback
@@ -25,6 +27,9 @@ SERVICE_RUN_RSYNC_JOB = "run_rsync_job"
 
 CONTAINER_COMMANDS = ["start", "stop", "restart", "pause", "unpause"]
 COMPOSE_COMMANDS = ["up -d", "down", "start", "stop", "pull"]
+
+# Docker container name/id charset (also matches short and full hashes).
+_CONTAINER_REF_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
 APPLY_CONFIG_SCHEMA = vol.Schema({vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string})
 
@@ -97,7 +102,9 @@ def _resolve_container_id(coordinator: OMVDataUpdateCoordinator, value: str) -> 
 
     Matches against ``container_key``, ``name`` and ``container_id`` of the
     normalized container records. Unknown values are passed through verbatim
-    so users can target containers OMV has not listed yet.
+    so users can target containers OMV has not listed yet, but are validated
+    against the Docker name/id charset first since OMV's compose plugin
+    builds a shell command server-side from this value.
 
     Args:
         coordinator: The coordinator holding ``data["compose"]``.
@@ -105,6 +112,10 @@ def _resolve_container_id(coordinator: OMVDataUpdateCoordinator, value: str) -> 
 
     Returns:
         The Docker container id, or ``value`` unchanged when unmatched.
+
+    Raises:
+        ServiceValidationError: When an unmatched ``value`` contains
+            characters outside the Docker name/id charset.
     """
     for record in coordinator.data.get("compose", []):
         if value in (
@@ -113,6 +124,12 @@ def _resolve_container_id(coordinator: OMVDataUpdateCoordinator, value: str) -> 
             record.get("container_id"),
         ):
             return str(record.get("container_id") or value)
+    if not _CONTAINER_REF_RE.fullmatch(value):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_container_reference",
+            translation_placeholders={"container": value},
+        )
     return value
 
 

--- a/custom_components/omv/strings.json
+++ b/custom_components/omv/strings.json
@@ -338,6 +338,9 @@
         "service_job_not_found": {
             "message": "Rsync job {job} was not found on the OMV host."
         },
+        "invalid_container_reference": {
+            "message": "Container reference {container} contains characters that are not valid in a Docker name or id."
+        },
         "wol_failed": {
             "message": "Failed to send the Wake-on-LAN magic packet for {interface}."
         }

--- a/custom_components/omv/translations/de.json
+++ b/custom_components/omv/translations/de.json
@@ -347,6 +347,9 @@
     "service_job_not_found": {
       "message": "Rsync-Job {job} wurde auf dem OMV-Host nicht gefunden."
     },
+    "invalid_container_reference": {
+      "message": "Container-Referenz {container} enthält Zeichen, die in einem Docker-Namen oder einer Docker-Id nicht zulässig sind."
+    },
     "wol_failed": {
       "message": "Wake-on-LAN-Paket für {interface} konnte nicht gesendet werden."
     }

--- a/custom_components/omv/translations/en.json
+++ b/custom_components/omv/translations/en.json
@@ -347,6 +347,9 @@
     "service_job_not_found": {
       "message": "Rsync job {job} was not found on the OMV host."
     },
+    "invalid_container_reference": {
+      "message": "Container reference {container} contains characters that are not valid in a Docker name or id."
+    },
     "wol_failed": {
       "message": "Failed to send the Wake-on-LAN magic packet for {interface}."
     }


### PR DESCRIPTION
## Proposed change

Bundles fixes for a set of security-review findings (1 Medium, 6 Low) into a v2.6.1 release. None were runtime-critical for end users (the shipped integration manifest has `"requirements": []`), but all are cheap defense-in-depth wins:

- **M1 — Unvalidated container reference passed to OMV's compose RPC** (`services.py`): `_resolve_container_id()` now validates unmatched user input against the Docker name/id charset (`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`) before it reaches `Compose.doContainerCommand` on the NAS, raising `ServiceValidationError` (new `invalid_container_reference` translation key, EN/DE) instead of passing free text through verbatim. The "target unlisted containers" feature still works since Docker names/ids always match that charset.
- **L1 — Credential metadata in debug logs**: dropped `password_length` from the debug logs in `omv_api.py` and `config_flow.py` (kept the non-sensitive whitespace-flag signal); trimmed the `Kvm.doCommand` debug log in `coordinator.py` to just `command`/`name` instead of the full params/response.
- **L2 — Unpinned GitHub Action `@master`**: pinned `home-assistant/actions/hassfest@master` to a commit SHA in `ci.yml`, matching the existing pin style used for `hacs/action`.
- **L3 — Vulnerable dev/test dependencies**: added a non-blocking `pip-audit` step to CI for visibility. Deliberately **not** bumping the pinned `pytest-homeassistant-custom-component` test stack in this PR — that's higher-risk and better done as its own change.
- **L4 — Over-broad sudo suggestion in deploy script**: `deploy-to-homeassistant.sh`'s header comment now recommends a scoped sudoers entry (`cp`, `rm -rf` on the fixed target path, `docker compose restart`, `docker inspect`) instead of `NOPASSWD: ALL`. Script logic is unchanged.
- **L5 — `hostname` not redacted in diagnostics**: added `"hostname"` to `TO_REDACT` in `diagnostics.py` for parity with the rest of the redaction policy.

Also bumps `manifest.json` to `2.6.1` and pins the `CHANGELOG.md` `[Unreleased]` entries under `## [2.6.1] - 2026-07-04`.

## Type of change
- [x] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

Not addressed here (out of scope by design):
- Full dependency bump for the vulnerable test-stack packages (L3) — runtime is unaffected since the shipped integration has no pinned requirements; tracked as a follow-up.

## Checklist
- [x] The code change is tested and works locally (`pytest tests -q`: 307 passed).
- [x] The code has been formatted/linted (`ruff check`, `ruff format --check`: clean).
- [ ] Tests have been added to verify that the new code works. *(existing container-command tests cover the resolver; no new negative-path test added for the injection-guard — happy to add one if desired)*
- [x] Documentation added/updated (`CHANGELOG.md`, docstring for `_resolve_container_id`).

Note: `mypy custom_components/omv` reports 23 pre-existing errors, identical before and after this change (verified via `git stash`) — none touch the lines modified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)