### PR TITLE
feat(ci): add deterministic HA REST smoke-test workflow on ephemeral k8s runner

### DIFF
--- a/.github/instructions/autopilot-completion.instructions.md
+++ b/.github/instructions/autopilot-completion.instructions.md
@@ -26,11 +26,11 @@ This instruction applies whenever a cohesive Autopilot task in the repository is
 - Wait until Home Assistant has finished starting up (the script waits automatically; alternatively confirm via MCP).
 - A task is not finished unless the deploy succeeds and Home Assistant is back online.
 
-## 4) HA MCP smoke test is mandatory
+## 4) Pipeline smoke test is the authoritative check
 
-- After a successful deploy, use the Home Assistant MCP tools to verify the integration is working.
-- Check that at least one OMV entity delivers a non-`unavailable` state, e.g. via `mcp_homeassistant_ha_search_entities` with `omv` as the query, then `mcp_homeassistant_ha_get_state` for a representative entity (e.g. a disk or memory sensor).
-- Until this smoke test confirms live data, the work must not be reported as complete.
+- The deterministic check lives in CI: `.github/workflows/smoke-test.yml` deploys to the Pi and polls the HA REST API (`sensor.omv_cpu_utilization`/`sensor.omv_memory_usage`) on every PR against `main` and on `workflow_dispatch`. A green check is required before merge.
+- For local/interactive confidence before opening the PR, you may additionally use the Home Assistant MCP tools to verify at least one OMV entity delivers a non-`unavailable` state, e.g. via `mcp_homeassistant_ha_search_entities` with `omv` as the query, then `mcp_homeassistant_ha_get_state` for a representative entity (e.g. a disk or memory sensor). MCP is not a gate — it does not replace the CI check.
+- Until the CI smoke-test check is green (or, for local-only confidence, MCP confirms live data), the work must not be reported as complete.
 
 ## 5) Failure handling
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Verify OMV entities via HA REST API (deterministic)
         run: |
           set -euo pipefail
-          entities=("sensor.omv_cpu_utilization" "sensor.omv_memory_usage")
+          entities=("sensor.omv_omv8_cpu_auslastung" "sensor.omv_omv8_speicherauslastung")
           max_wait=90
 
           for entity in "${entities[@]}"; do

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,6 +31,12 @@ jobs:
     # already present) and matches the runtime actions/checkout itself needs.
     container:
       image: node:24-bookworm
+    # GitHub Actions defaults run: steps to `sh` (not bash) when a job
+    # container is set, and dash's `set` doesn't support `-o pipefail`,
+    # which every multi-command step below relies on.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,128 @@
+---
+name: "HA Smoke Test"
+
+# Only one deploy+verify against the single production Pi/HA instance at a
+# time — parallel PR runs would otherwise race on the same target.
+concurrency:
+  group: ha-smoke-test
+  cancel-in-progress: false
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # renovate: datasource=github-releases depName=mikefarah/yq
+  YQ_VERSION: "v4.53.3"
+
+jobs:
+  smoke:
+    name: Deploy + REST verify on Pi
+    # Ephemeral ARC runner (org-scoped, kubernetes containerMode) — see
+    # homelab kubernetes/apps/arc-runners. Fresh pod per run, nothing persists.
+    runs-on: k8s
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install CLI dependencies (ephemeral pod)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends openssh-client rsync jq
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Fetch SSH key from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          domain: ${{ vars.INFISICAL_URL }}
+          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          secret-path: /ci/ssh
+
+      - name: Fetch HA URL/token from Infisical
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
+          client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          domain: ${{ vars.INFISICAL_URL }}
+          project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
+          env-slug: prod
+          secret-path: /ci/homeassistant
+
+      - name: Setup SSH config for the pi
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s' "$SSH_KEYS_YAML" > /tmp/ssh-keys.yaml
+
+          cat > ~/.ssh/config <<-'EOF'
+          Host *
+            StrictHostKeyChecking accept-new
+            UserKnownHostsFile ~/.ssh/known_hosts
+          EOF
+
+          host_ip=$(yq eval '.hosts.raspi.ip' /tmp/ssh-keys.yaml)
+          host_user=$(yq eval '.hosts.raspi.user' /tmp/ssh-keys.yaml)
+          host_port=$(yq eval '.hosts.raspi.port' /tmp/ssh-keys.yaml)
+
+          cat >> ~/.ssh/config <<-EOF
+          Host pi
+            HostName ${host_ip}
+            User ${host_user}
+            Port ${host_port}
+            IdentityFile ~/.ssh/pi_key
+            IdentitiesOnly yes
+          EOF
+
+          yq eval '.ssh_keys.raspi' /tmp/ssh-keys.yaml > ~/.ssh/pi_key
+          chmod 600 ~/.ssh/pi_key ~/.ssh/config
+          ssh-keyscan -H "${host_ip}" >> ~/.ssh/known_hosts 2>/dev/null
+          rm -f /tmp/ssh-keys.yaml
+
+      - name: Deploy to Home Assistant
+        run: bash .github/scripts/deploy-to-homeassistant.sh
+
+      - name: Verify OMV entities via HA REST API (deterministic)
+        run: |
+          set -euo pipefail
+          entities=("sensor.omv_cpu_utilization" "sensor.omv_memory_usage")
+          max_wait=90
+
+          for entity in "${entities[@]}"; do
+            echo "==> Polling ${entity}..."
+            elapsed=0
+            state=""
+            while true; do
+              # Bearer token goes over curl's stdin config (-K -), not argv,
+              # so it never shows up in `ps` on the remote pi. Heredoc is
+              # intentionally unquoted: ${entity}/${HA_TOKEN} must expand
+              # locally (client-side) since only the runner has HA_TOKEN.
+              # shellcheck disable=SC2029,SC2087
+              state=$(ssh pi "curl -sf --max-time 5 -K - http://localhost:8123/api/states/${entity}" <<HDR | jq -r '.state // empty'
+          header = "Authorization: Bearer ${HA_TOKEN}"
+          HDR
+              ) || state=""
+
+              if [[ "${state}" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+                echo "    ${entity} = ${state}"
+                break
+              fi
+
+              if [[ ${elapsed} -ge ${max_wait} ]]; then
+                echo "ERROR: ${entity} did not report a numeric state within ${max_wait}s (last state: '${state}')" >&2
+                exit 1
+              fi
+
+              sleep 5
+              elapsed=$((elapsed + 5))
+            done
+          done
+
+          echo "✅ Smoke test passed: OMV entities report live numeric state."

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -25,16 +25,22 @@ jobs:
     # Ephemeral ARC runner (org-scoped, kubernetes containerMode) — see
     # homelab kubernetes/apps/arc-runners. Fresh pod per run, nothing persists.
     runs-on: k8s
+    # ARC's kubernetes containerMode enforces ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER,
+    # so every job must declare its own container or the runner refuses to run
+    # any step. node:*-bookworm is buildpack-deps-based (git/curl/openssh-client
+    # already present) and matches the runtime actions/checkout itself needs.
+    container:
+      image: node:24-bookworm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
       - name: Install CLI dependencies (ephemeral pod)
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends openssh-client rsync jq
-          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
-          sudo chmod +x /usr/local/bin/yq
+          apt-get update -qq
+          apt-get install -y --no-install-recommends openssh-client rsync jq
+          wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          chmod +x /usr/local/bin/yq
 
       - name: Fetch SSH key from Infisical
         uses: Infisical/secrets-action@v1.0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- CI smoke-test workflow (`.github/workflows/smoke-test.yml`): deploys to the Pi and deterministically verifies OMV entities via the HA REST API on every PR against `main` and on `workflow_dispatch`, replacing the MCP-based check as the merge gate.
+
+## [2.6.1] - 2026-07-04
+
+### Changed
+
+- The `container_command` service now validates unmatched container references against the Docker name/id charset before passing them to OMV's compose RPC, closing a defense-in-depth gap where free-text input reached a server-side shell command unvalidated.
+- Debug logs no longer include password length; only the (non-sensitive) outer-whitespace flag is kept.
+- The `Kvm.doCommand` debug log now only records the command and VM name instead of the full request/response payload.
+- CI's `hassfest` action is now pinned to a commit SHA instead of the mutable `@master` ref.
+- CI now runs a non-blocking `pip-audit` step to surface vulnerable dependencies.
+- The deploy script's sudoers guidance now recommends a scoped sudo entry for the specific commands it runs, instead of `NOPASSWD: ALL`.
+- Diagnostics now redact the OMV `hostname` field, matching the existing redaction of other identifying fields.
+
 ### Fixed
 
 - Apply-config button now awaits the `persistent_notification.dismiss` service call instead of firing it without awaiting, which produced a "coroutine was never awaited" warning during tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Before claiming a task complete:
 1. **Local validation** — run `pytest tests/ -q` (or a focused subset). No failures allowed.
 2. **Commit** — one conventional commit per completed task (do not push; CI handles that).
 3. **Deploy** — run the VS Code task `HASS: Deploy to HomeAssistant (SSH)` (or `.github/scripts/deploy-to-homeassistant.sh`) and wait for Home Assistant to come back online.
-4. **Smoke test** — use the Home Assistant MCP tools to confirm at least one OMV entity returns a non-`unavailable` state (e.g. `mcp_homeassistant_ha_search_entities` → `mcp_homeassistant_ha_get_state`).
+4. **Smoke test** — for local/interactive confidence, use the Home Assistant MCP tools to confirm at least one OMV entity returns a non-`unavailable` state (e.g. `mcp_homeassistant_ha_search_entities` → `mcp_homeassistant_ha_get_state`). The authoritative check is deterministic and runs in CI: `.github/workflows/smoke-test.yml` deploys to the Pi and polls the HA REST API for `sensor.omv_cpu_utilization`/`sensor.omv_memory_usage` on every PR against `main` — MCP does not gate merges, the CI check does.
 5. **Failure handling** — if any step fails, report the failed step, error signal, and the next repair step. Do not claim completion.
 
 ## Security Guidelines


### PR DESCRIPTION
## Summary
- New `.github/workflows/smoke-test.yml`: deploys to the Pi via SSH and polls the HA REST API for `sensor.omv_cpu_utilization`/`sensor.omv_memory_usage` on every PR against `main` and on `workflow_dispatch` — deterministic, replaces the MCP-based manual check as the merge gate.
- Runs on `runs-on: k8s`, the new org-scoped ARC ephemeral runner (see `slydlake/homelab` `kubernetes/apps/arc-runners`), not the persistent raspi runner — keeps the production deploy pipeline's runner untouched.
- Bearer token for the HA REST call is passed to the remote `curl` via `-K -` (stdin config), never as an argv arg, so it never appears in `ps` on the Pi.
- Docs updated (`CLAUDE.md`, `.github/instructions/autopilot-completion.instructions.md`, `CHANGELOG.md`) to reflect CI as the authoritative gate, MCP as optional local confidence only.

## Test plan
- [x] `actionlint` clean (only the expected "unknown custom runner label k8s" note)
- [ ] This PR's own `smoke-test.yml` run (triggered by opening this PR against `main`) completes successfully on the `k8s` runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)