### PR TITLE
fix(auth): TOTP auto-relogin via stored secret + session handoff keying/leak fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ### Added
 
+- Optional TOTP secret in the two-factor config-flow step (`totp.py`, stdlib-only RFC 6238 generator): when stored, the integration answers OMV's 2FA challenge automatically on every re-login (session expiry, HA restarts), with ±30 s clock-skew tolerance (Issue #55).
 - CI smoke-test workflow (`.github/workflows/smoke-test.yml`): deploys to the Pi and deterministically verifies OMV entities via the HA REST API on every PR against `main` and on `workflow_dispatch`, replacing the MCP-based check as the merge gate.
+
+### Fixed
+
+- 2FA accounts no longer dead-end in a reauth loop on every session expiry or HA restart when a TOTP secret is stored; without a secret, the coordinator's auth-failure message now explains that reauthenticating with a stored secret enables automatic re-logins (Issue #55).
+- Reauth/reconfigure session hand-off is now keyed by the entry's `unique_id` instead of the freshly computed hostname, so multi-instance setups can no longer miss or cross their hand-offs (Issue #55).
+- `async_unload_entry` now closes the previous API session after a reauth/reconfigure instead of leaking it; only the options-reload hand-off (same instance) is kept open (Issue #55).
 
 ## [2.6.1] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.6.2] - 2026-07-05
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ The config flow asks for:
 | **SSL** | off | Enable if your OMV is reachable via HTTPS |
 | **SSL verification** | on | Disable only when using a self-signed certificate |
 
+### Two-factor authentication (TOTP)
+
+If the OMV account has 2FA enabled (OMV 8.5+), the config flow asks for a second factor after the credentials step. You can provide **either**:
+
+- **Verification code** — a one-time 6-digit code from your authenticator app. It is valid for this login only: after a Home Assistant restart or an expired OMV session, Home Assistant will ask you to reauthenticate.
+- **TOTP secret** (recommended) — the Base32 secret behind your authenticator entry. It is stored with the config entry (same confidentiality class as the password) and lets the integration answer OMV's 2FA challenge automatically, so restarts and session expiry no longer require manual reauthentication.
+
+You can copy the secret from OMV at any time — even after 2FA has already been set up: in the OMV WebUI open **Users** > **2FA TOTP**, select your username, and copy the displayed secret.
+
 ### Using a dedicated (non-`admin`) OMV user
 
 OMV's API only recognizes two access levels: **Administrator** and plain **User**, decided solely by membership in the `openmediavault-admin` system group. Every RPC this integration calls — disks, SMART, filesystems, network, services, Compose, KVM, ZFS, rsync, cron, etc. — requires the Administrator role; there is no finer-grained or read-only permission level to scope it down to.

--- a/custom_components/omv/__init__.py
+++ b/custom_components/omv/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import entity_registry as er
 from . import session_handoff
 from .const import (
     CONF_SCAN_INTERVAL,
+    CONF_TOTP_SECRET,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SSL,
@@ -144,6 +145,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool:
             ssl=entry.data.get(CONF_SSL, DEFAULT_SSL),
             verify_ssl=entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
             source="setup_entry",
+            totp_secret=entry.data.get(CONF_TOTP_SECRET),
         )
 
         try:
@@ -178,12 +180,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         async_delete_reboot_repair_issue(hass, entry.entry_id)
-        # If _async_update_listener just stashed a live, already-authenticated
+        # If _async_update_listener just stashed THIS live, already-authenticated
         # session for the immediate reload below, leave it open — closing it
         # here would force the reload's async_setup_entry into a brand new
         # OMV login, re-triggering a 2FA challenge for a session that was
-        # still perfectly valid.
-        if not session_handoff.has_pending(entry.unique_id):
+        # still perfectly valid. A pending hand-off holding a DIFFERENT
+        # instance (reauth/reconfigure just authenticated a new session)
+        # means the old one is obsolete and must be closed, or it leaks.
+        if not session_handoff.pending_api_is(entry.unique_id, entry.runtime_data.api):
             await entry.runtime_data.api.async_close()
     return unload_ok
 

--- a/custom_components/omv/config_flow.py
+++ b/custom_components/omv/config_flow.py
@@ -26,7 +26,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
-from . import session_handoff
+from . import session_handoff, totp
 from .const import (
     CONF_REBOOT_REPAIR_DISABLED,
     CONF_SCAN_INTERVAL,
@@ -42,6 +42,7 @@ from .const import (
     CONF_SELECTED_ZFS_POOLS,
     CONF_SMART_INTERVAL,
     CONF_SMART_POLLING_DISABLED,
+    CONF_TOTP_SECRET,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SSL,
@@ -167,28 +168,21 @@ class OMVConfigFlow(ConfigFlow, domain=DOMAIN):
         accounts, immediately challenged) OMV login. If the flow aborts
         instead (e.g. a unique-ID mismatch), the hand-off never happens and
         the session is closed here.
+
+        For reauth/reconfigure the hand-off is keyed by the entry's existing
+        ``unique_id`` — that is the key ``async_setup_entry`` pops — instead
+        of the freshly computed hostname, so the two can never diverge
+        (Issue #55). For brand new entries both are identical because
+        ``async_set_unique_id(hostname)`` just ran.
         """
-        if self.source == SOURCE_RECONFIGURE:
-            entry = self._get_reconfigure_entry()
+        if self.source in (SOURCE_RECONFIGURE, SOURCE_REAUTH):
+            entry = self._get_reconfigure_entry() if self.source == SOURCE_RECONFIGURE else self._get_reauth_entry()
             try:
                 self._abort_if_unique_id_mismatch()
             except Exception:
                 await api.async_close()
                 raise
-            session_handoff.store(hostname, api, system_info)
-            return self.async_update_reload_and_abort(
-                entry,
-                title=f"OMV ({hostname})",
-                data=data,
-            )
-        if self.source == SOURCE_REAUTH:
-            entry = self._get_reauth_entry()
-            try:
-                self._abort_if_unique_id_mismatch()
-            except Exception:
-                await api.async_close()
-                raise
-            session_handoff.store(hostname, api, system_info)
+            session_handoff.store(entry.unique_id or hostname, api, system_info)
             return self.async_update_reload_and_abort(
                 entry,
                 title=f"OMV ({hostname})",
@@ -283,37 +277,77 @@ class OMVConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    def _existing_totp_secret(self) -> str | None:
+        """Return the TOTP secret already stored on the entry being reauthed/reconfigured."""
+        if self.source == SOURCE_RECONFIGURE:
+            entry: ConfigEntry | None = self._get_reconfigure_entry()
+        elif self.source == SOURCE_REAUTH:
+            entry = self._get_reauth_entry()
+        else:
+            entry = None
+        if entry is None:
+            return None
+        secret = entry.data.get(CONF_TOTP_SECRET)
+        return secret if isinstance(secret, str) and secret else None
+
     async def async_step_totp(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Handle the second step of a two-factor OMV login."""
+        """Handle the second step of a two-factor OMV login.
+
+        Accepts either a one-time verification code or the Base32 TOTP secret
+        itself (exactly one of the two). When the secret is provided, the code
+        is generated locally, verified against OMV, and the secret is stored
+        in the entry data so the integration can answer future 2FA challenges
+        (session expiry, HA restarts) without user interaction (Issue #55).
+        """
         errors: dict[str, str] = {}
         api = self._pending_api
 
         if user_input is not None and api is not None:
-            try:
-                system_info = await api.async_submit_two_factor_code(user_input[CONF_TOTP_CODE])
-            except OMVAuthError as err:
-                _LOGGER.debug("OMV config flow invalid_totp_code: %s", err)
-                errors["base"] = "invalid_totp_code"
-            except OMVConnectionError as err:
-                _LOGGER.debug("OMV config flow cannot_connect during 2FA verification: %s", err)
-                errors["base"] = "cannot_connect"
-                await api.async_close()
-                self._pending_api = None
-            except Exception:
-                _LOGGER.exception("Unexpected error during OMV 2FA verification")
-                errors["base"] = "unknown"
-                await api.async_close()
-                self._pending_api = None
+            code = str(user_input.get(CONF_TOTP_CODE) or "").strip()
+            secret = str(user_input.get(CONF_TOTP_SECRET) or "").strip()
+            if bool(code) == bool(secret):
+                errors["base"] = "totp_code_or_secret_required"
+            elif secret and not totp.is_valid_secret(secret):
+                errors["base"] = "invalid_totp_secret"
             else:
-                assert self._pending_user_input is not None
-                hostname = str(system_info.get("hostname") or self._pending_user_input[CONF_HOST])
-                self._pending_api = None
-                await self.async_set_unique_id(hostname)
-                return await self._finish_flow(hostname, self._pending_user_input, api, system_info)
+                try:
+                    system_info = await api.async_submit_two_factor_code(code or totp.generate_code(secret))
+                except OMVAuthError as err:
+                    _LOGGER.debug("OMV config flow 2FA verification rejected: %s", err)
+                    errors["base"] = "invalid_totp_secret" if secret else "invalid_totp_code"
+                except OMVConnectionError as err:
+                    _LOGGER.debug("OMV config flow cannot_connect during 2FA verification: %s", err)
+                    errors["base"] = "cannot_connect"
+                    await api.async_close()
+                    self._pending_api = None
+                except Exception:
+                    _LOGGER.exception("Unexpected error during OMV 2FA verification")
+                    errors["base"] = "unknown"
+                    await api.async_close()
+                    self._pending_api = None
+                else:
+                    assert self._pending_user_input is not None
+                    data = dict(self._pending_user_input)
+                    # Keep a previously stored secret when the user verified with
+                    # a one-time code during reauth/reconfigure — dropping it
+                    # would silently disable automatic re-logins again.
+                    stored_secret = secret or self._existing_totp_secret()
+                    if stored_secret:
+                        data[CONF_TOTP_SECRET] = stored_secret
+                        api.set_totp_secret(stored_secret)
+                    hostname = str(system_info.get("hostname") or data[CONF_HOST])
+                    self._pending_api = None
+                    await self.async_set_unique_id(hostname)
+                    return await self._finish_flow(hostname, data, api, system_info)
 
         return self.async_show_form(
             step_id="totp",
-            data_schema=vol.Schema({vol.Required(CONF_TOTP_CODE): str}),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_TOTP_CODE): str,
+                    vol.Optional(CONF_TOTP_SECRET): str,
+                }
+            ),
             errors=errors,
         )
 

--- a/custom_components/omv/const.py
+++ b/custom_components/omv/const.py
@@ -18,6 +18,9 @@ DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
 
+# Optionales TOTP-Secret (entry.data) für automatische Re-Logins bei 2FA (Issue #55)
+CONF_TOTP_SECRET = "totp_secret"
+
 # Optionsschlüssel für auswählbare Ressourcen
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_REBOOT_REPAIR_DISABLED = "reboot_repair_disabled"

--- a/custom_components/omv/coordinator.py
+++ b/custom_components/omv/coordinator.py
@@ -33,7 +33,12 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
-from .exceptions import OMVApiError, OMVAuthError, OMVConnectionError
+from .exceptions import (
+    OMVApiError,
+    OMVAuthError,
+    OMVConnectionError,
+    OMVTwoFactorRequiredError,
+)
 from .omv_api import OMVAPI
 
 _LOGGER = logging.getLogger(__name__)
@@ -445,10 +450,18 @@ class OMVDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 unfiltered_data,
                 dict(self.config_entry.options),
             )
+        except OMVTwoFactorRequiredError as err:
+            # OMV challenged a fresh re-login and no TOTP secret is stored, so
+            # nobody can answer it — reauthenticating (and storing the TOTP
+            # secret there) enables automatic re-logins instead (Issue #55).
+            raise ConfigEntryAuthFailed(
+                "OMV re-login requires a two-factor code and no TOTP secret is "
+                "stored; reauthenticate and provide the TOTP secret to enable "
+                f"automatic re-logins: {err}"
+            ) from err
         except OMVAuthError as err:
-            # A 2FA challenge (or any other auth failure) surviving the API
-            # client's own automatic reconnect means nobody is present to
-            # answer it — falling back to cached data here would leave
+            # An auth failure surviving the API client's own automatic
+            # reconnect — falling back to cached data here would leave
             # entities silently frozen on stale values forever instead of
             # prompting the user to reauthenticate.
             raise ConfigEntryAuthFailed(f"OMV authentication failed: {err}") from err

--- a/custom_components/omv/diagnostics.py
+++ b/custom_components/omv/diagnostics.py
@@ -11,6 +11,8 @@ from homeassistant.core import HomeAssistant
 TO_REDACT = {
     "username",
     "password",
+    # TOTP shared secret — same confidentiality class as the password
+    "totp_secret",
     # Hardware identifiers that can de-anonymise a user's device
     "serialnumber",
     "address",  # IP address of network interfaces

--- a/custom_components/omv/omv_api.py
+++ b/custom_components/omv/omv_api.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 import aiohttp
 from yarl import URL
 
+from . import totp
 from .exceptions import (
     OMVApiError,
     OMVAuthError,
@@ -39,6 +41,7 @@ class OMVAPI:
         ssl: bool = False,
         verify_ssl: bool = True,
         source: str = "runtime",
+        totp_secret: str | None = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -47,9 +50,23 @@ class OMVAPI:
         self._ssl = ssl
         self._verify_ssl = verify_ssl
         self._source = source
+        self._totp_secret = totp_secret
         self._session_id: str | None = None
         self._session: aiohttp.ClientSession | None = None
         self._lock = asyncio.Lock()
+
+    def set_totp_secret(self, totp_secret: str | None) -> None:
+        """Set the TOTP secret used to answer 2FA challenges automatically.
+
+        Needed by the config flow, which learns the secret only after the
+        API instance was created (in the ``totp`` step) but hands exactly
+        this instance off to the runtime setup afterwards.
+
+        Args:
+            totp_secret: Base32-encoded shared secret, or None to disable
+                automatic challenge answering.
+        """
+        self._totp_secret = totp_secret
 
     @property
     def base_url(self) -> str:
@@ -114,15 +131,21 @@ class OMVAPI:
         - Legacy (OMV 7, pre-2FA OMV 8): ``{"authenticated": true, "sessionid": ...}``.
         - Current (OMV 8.5+, native TOTP 2FA support): ``{"status": "authenticated",
           "sessionid": ...}`` on success, or ``{"status": "challengeRequired", ...}``
-          when the account has two-factor authentication enabled. The latter
-          raises :class:`~custom_components.omv.exceptions.OMVTwoFactorRequiredError`
-          so callers (e.g. the config flow) can complete the challenge via
+          when the account has two-factor authentication enabled. When a TOTP
+          secret is configured, a ``totp`` challenge is answered automatically
+          via :meth:`_async_answer_totp_challenge` (Issue #55) so session
+          expiry and HA restarts don't dead-end in a challenge nobody can
+          answer. Without a secret, the challenge raises
+          :class:`~custom_components.omv.exceptions.OMVTwoFactorRequiredError`
+          so callers (e.g. the config flow) can complete it via
           :meth:`async_submit_two_factor_code`.
 
         Raises:
-            OMVAuthError: If the credentials are rejected.
+            OMVAuthError: If the credentials are rejected, or a TOTP challenge
+                could not be answered with the configured secret.
             OMVTwoFactorRequiredError: If the account requires two-factor
-                authentication to complete the login.
+                authentication and no TOTP secret is configured (or the
+                challenge is of an unsupported kind).
         """
         self._session_id = None
         data = await self._async_raw_call(
@@ -151,6 +174,18 @@ class OMVAPI:
                 challenge_kind = (
                     isinstance(data, dict) and isinstance(data.get("challenge"), dict) and data["challenge"].get("kind")
                 )
+                if challenge_kind == "totp" and self._totp_secret:
+                    data = await self._async_answer_totp_challenge()
+                    session_id = data.get("sessionid")
+                    if isinstance(session_id, str) and session_id:
+                        self._session_id = session_id
+                    _LOGGER.debug(
+                        "Automatically answered OMV TOTP challenge for %s [%s]; sessionid_present=%s",
+                        self._host,
+                        self._source,
+                        self._session_id is not None,
+                    )
+                    return
                 raise OMVTwoFactorRequiredError(
                     f"OMV account requires two-factor authentication (challenge kind={challenge_kind!r})",
                     challenge_kind=challenge_kind if isinstance(challenge_kind, str) else None,
@@ -168,6 +203,59 @@ class OMVAPI:
             self._session_id is not None,
             self._cookie_names(),
         )
+
+    async def _async_answer_totp_challenge(self) -> dict[str, Any]:
+        """Answer a pending TOTP challenge with the configured secret.
+
+        Generates the RFC 6238 code locally and submits it via
+        ``Session.verify`` on the same aiohttp session — OMV binds the pending
+        login to the PHP session cookie set by ``Session.login``. If the
+        current-window code is rejected, the neighbouring 30-second windows
+        (±``totp.TIME_STEP``) are tried once each to tolerate clock skew
+        between the HA host and the NAS.
+
+        Returns:
+            The successful ``Session.verify`` response
+            (``{"status": "authenticated", "sessionid": ...}``).
+
+        Raises:
+            OMVAuthError: When every candidate code is rejected (wrong secret,
+                or the pending login already expired server-side).
+            OMVConnectionError: When the OMV host is unreachable.
+        """
+        assert self._totp_secret is not None
+        now = time.time()
+        candidates: list[str] = []
+        for offset in (0, -totp.TIME_STEP, totp.TIME_STEP):
+            code = totp.generate_code(self._totp_secret, now + offset)
+            if code not in candidates:
+                candidates.append(code)
+
+        last_err: OMVAuthError | None = None
+        for attempt, code in enumerate(candidates):
+            try:
+                data = await self._async_raw_call(
+                    "session",
+                    "verify",
+                    {"code": code},
+                    options=None,
+                )
+            except OMVAuthError as err:
+                last_err = err
+                _LOGGER.debug(
+                    "OMV TOTP challenge answer rejected [%s] host=%r attempt=%d/%d",
+                    self._source,
+                    self._host,
+                    attempt + 1,
+                    len(candidates),
+                )
+                continue
+            status = data.get("status") if isinstance(data, dict) else None
+            if status == "authenticated":
+                return data if isinstance(data, dict) else {}
+            last_err = OMVAuthError(f"Two-factor verification failed (status={status!r})")
+
+        raise OMVAuthError("Two-factor verification with the stored TOTP secret failed") from last_err
 
     async def async_submit_two_factor_code(self, code: str) -> dict[str, Any]:
         """Complete a two-step OMV login by submitting the second-factor code.

--- a/custom_components/omv/session_handoff.py
+++ b/custom_components/omv/session_handoff.py
@@ -40,3 +40,16 @@ def pop(unique_id: str | None) -> tuple[OMVAPI, dict[str, Any]] | None:
 def has_pending(unique_id: str | None) -> bool:
     """Return whether an authenticated API instance is stashed for this host."""
     return unique_id is not None and unique_id in _pending
+
+
+def pending_api_is(unique_id: str | None, api: OMVAPI) -> bool:
+    """Return whether the stashed API instance for this host is exactly ``api``.
+
+    Lets ``async_unload_entry`` distinguish the options-reload hand-off (the
+    still-live instance it must not close) from a reauth/reconfigure hand-off
+    (a brand new instance — the old one must be closed or its session leaks).
+    """
+    if unique_id is None:
+        return False
+    pending = _pending.get(unique_id)
+    return pending is not None and pending[0] is api

--- a/custom_components/omv/strings.json
+++ b/custom_components/omv/strings.json
@@ -22,9 +22,14 @@
             },
             "totp": {
                 "title": "Two-factor authentication",
-                "description": "Enter the verification code from your authenticator app to finish signing in.",
+                "description": "Enter either a one-time verification code from your authenticator app, or your Base32 TOTP secret. When the secret is provided, it is stored so the integration can sign in again automatically (e.g. after a session expires or Home Assistant restarts).",
                 "data": {
-                    "code": "Verification code"
+                    "code": "Verification code",
+                    "totp_secret": "TOTP secret"
+                },
+                "data_description": {
+                    "code": "6-digit one-time code. Leave empty when providing the TOTP secret instead.",
+                    "totp_secret": "Optional: store the secret to enable automatic re-logins. Leave empty when providing a one-time code instead."
                 }
             }
         },
@@ -32,7 +37,9 @@
             "invalid_auth": "Invalid credentials",
             "invalid_totp_code": "Invalid or expired verification code",
             "cannot_connect": "Cannot connect to OMV",
-            "unknown": "Unknown error"
+            "unknown": "Unknown error",
+            "invalid_totp_secret": "Invalid TOTP secret or the generated code was rejected",
+            "totp_code_or_secret_required": "Enter either a verification code or the TOTP secret (exactly one)"
         },
         "abort": {
             "already_configured": "This OpenMediaVault host is already configured. Use Reconfigure to update its host, port, SSL or two-factor authentication settings instead of adding it again.",

--- a/custom_components/omv/strings.json
+++ b/custom_components/omv/strings.json
@@ -22,14 +22,14 @@
             },
             "totp": {
                 "title": "Two-factor authentication",
-                "description": "Enter either a one-time verification code from your authenticator app, or your Base32 TOTP secret. When the secret is provided, it is stored so the integration can sign in again automatically (e.g. after a session expires or Home Assistant restarts).",
+                "description": "Sign in with either a one-time verification code or your TOTP secret. A code is valid for this login only — after a Home Assistant restart or session expiry you will need to reauthenticate. The secret is stored and lets the integration sign in again automatically.",
                 "data": {
                     "code": "Verification code",
                     "totp_secret": "TOTP secret"
                 },
                 "data_description": {
-                    "code": "6-digit one-time code. Leave empty when providing the TOTP secret instead.",
-                    "totp_secret": "Optional: store the secret to enable automatic re-logins. Leave empty when providing a one-time code instead."
+                    "code": "6-digit one-time code from your authenticator app. Requires reauthentication after a Home Assistant restart or session expiry.",
+                    "totp_secret": "Base32 secret from your authenticator setup — enables automatic re-logins, no reauthentication after restarts. Leave the code field empty when using this."
                 }
             }
         },

--- a/custom_components/omv/totp.py
+++ b/custom_components/omv/totp.py
@@ -1,0 +1,106 @@
+"""RFC 6238 TOTP code generator using only the standard library.
+
+Implemented with stdlib ``base64``/``hmac`` instead of a PyPI dependency so
+the integration's ``manifest.json`` ``requirements`` stays empty
+(HACS-friendly, no version pinning against Home Assistant core) — the same
+rationale as :mod:`custom_components.omv.wol`.
+
+Only the parameters used by OMV's ``openmediavault-2fa-totp`` plugin are
+supported: HMAC-SHA1, 30-second time step, 6 digits.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import struct
+import time
+
+#: TOTP time step in seconds (RFC 6238 default, used by OMV's TOTP plugin).
+TIME_STEP = 30
+_DIGITS = 6
+
+
+def _normalize_secret(secret: str) -> str:
+    """Return the Base32 secret in canonical form (upper-case, padded).
+
+    Tolerates the formats authenticator apps commonly present: lower-case
+    letters, whitespace/dash grouping (``abcd efgh``) and missing ``=``
+    padding.
+
+    Args:
+        secret: The raw Base32-encoded shared secret as entered by the user.
+
+    Returns:
+        The normalized Base32 string, padded to a multiple of 8 characters.
+    """
+    compact = "".join(secret.split()).replace("-", "").upper()
+    if remainder := len(compact) % 8:
+        compact += "=" * (8 - remainder)
+    return compact
+
+
+def _decode_secret(secret: str) -> bytes:
+    """Decode a Base32 TOTP secret into its raw key bytes.
+
+    Args:
+        secret: The Base32-encoded shared secret (normalization tolerant).
+
+    Returns:
+        The decoded key bytes.
+
+    Raises:
+        ValueError: When the secret is empty or not valid Base32.
+    """
+    normalized = _normalize_secret(secret)
+    if not normalized:
+        raise ValueError("TOTP secret is empty")
+    try:
+        return base64.b32decode(normalized)
+    except (binascii.Error, ValueError) as err:
+        raise ValueError(f"Invalid Base32 TOTP secret: {err}") from err
+
+
+def is_valid_secret(secret: str) -> bool:
+    """Return whether a string is a usable Base32 TOTP secret.
+
+    Args:
+        secret: The candidate shared secret.
+
+    Returns:
+        True when the secret decodes to a non-empty key, False otherwise.
+    """
+    try:
+        return bool(_decode_secret(secret))
+    except ValueError:
+        return False
+
+
+def generate_code(secret: str, timestamp: float | None = None) -> str:
+    """Generate the 6-digit TOTP code for a shared secret (RFC 6238, SHA-1).
+
+    Args:
+        secret: The Base32-encoded shared secret.
+        timestamp: Unix timestamp to generate the code for. Defaults to the
+            current time; pass ``time.time() - TIME_STEP`` /
+            ``time.time() + TIME_STEP`` for the neighbouring windows to
+            tolerate clock skew.
+
+    Returns:
+        The zero-padded 6-digit code valid for the 30-second window
+        containing ``timestamp``.
+
+    Raises:
+        ValueError: When the secret is empty or not valid Base32.
+    """
+    key = _decode_secret(secret)
+    if timestamp is None:
+        timestamp = time.time()
+    counter = int(timestamp // TIME_STEP)
+    digest = hmac.new(key, struct.pack(">Q", counter), hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    (code,) = struct.unpack(">I", digest[offset : offset + 4])
+    code &= 0x7FFFFFFF
+    return str(code % 10**_DIGITS).zfill(_DIGITS)

--- a/custom_components/omv/translations/de.json
+++ b/custom_components/omv/translations/de.json
@@ -22,9 +22,14 @@
       },
       "totp": {
         "title": "Zwei-Faktor-Authentifizierung",
-        "description": "Gib den Verifizierungscode aus deiner Authenticator-App ein, um die Anmeldung abzuschließen.",
+        "description": "Gib entweder einen einmaligen Verifizierungscode aus deiner Authenticator-App ein oder dein Base32-TOTP-Secret. Wird das Secret angegeben, wird es gespeichert, damit sich die Integration automatisch neu anmelden kann (z. B. nach Ablauf der Sitzung oder einem Home-Assistant-Neustart).",
         "data": {
-          "code": "Verifizierungscode"
+          "code": "Verifizierungscode",
+          "totp_secret": "TOTP-Secret"
+        },
+        "data_description": {
+          "code": "6-stelliger Einmalcode. Leer lassen, wenn stattdessen das TOTP-Secret angegeben wird.",
+          "totp_secret": "Optional: Secret speichern für automatische Re-Logins. Leer lassen, wenn stattdessen ein Einmalcode angegeben wird."
         }
       }
     },
@@ -32,7 +37,9 @@
       "invalid_auth": "Ungültige Zugangsdaten",
       "invalid_totp_code": "Ungültiger oder abgelaufener Verifizierungscode",
       "cannot_connect": "Verbindung zu OMV nicht möglich",
-      "unknown": "Unbekannter Fehler"
+      "unknown": "Unbekannter Fehler",
+      "invalid_totp_secret": "Ungültiges TOTP-Secret oder der erzeugte Code wurde abgelehnt",
+      "totp_code_or_secret_required": "Gib entweder einen Verifizierungscode oder das TOTP-Secret ein (genau eines von beiden)"
     },
     "abort": {
       "already_configured": "Dieser OpenMediaVault-Host ist bereits konfiguriert. Verwende „Neu konfigurieren“, um Host, Port, SSL- oder Zwei-Faktor-Authentifizierungs-Einstellungen zu ändern, anstatt ihn erneut hinzuzufügen.",

--- a/custom_components/omv/translations/de.json
+++ b/custom_components/omv/translations/de.json
@@ -22,14 +22,14 @@
       },
       "totp": {
         "title": "Zwei-Faktor-Authentifizierung",
-        "description": "Gib entweder einen einmaligen Verifizierungscode aus deiner Authenticator-App ein oder dein Base32-TOTP-Secret. Wird das Secret angegeben, wird es gespeichert, damit sich die Integration automatisch neu anmelden kann (z. B. nach Ablauf der Sitzung oder einem Home-Assistant-Neustart).",
+        "description": "Melde dich entweder mit einem einmaligen Verifizierungscode oder mit deinem TOTP-Secret an. Ein Code gilt nur für diese Anmeldung — nach einem Home-Assistant-Neustart oder Sitzungsablauf ist eine erneute Reauthentifizierung nötig. Das Secret wird gespeichert und ermöglicht der Integration eine automatische Neuanmeldung.",
         "data": {
           "code": "Verifizierungscode",
           "totp_secret": "TOTP-Secret"
         },
         "data_description": {
-          "code": "6-stelliger Einmalcode. Leer lassen, wenn stattdessen das TOTP-Secret angegeben wird.",
-          "totp_secret": "Optional: Secret speichern für automatische Re-Logins. Leer lassen, wenn stattdessen ein Einmalcode angegeben wird."
+          "code": "6-stelliger Einmalcode aus deiner Authenticator-App. Benötigt nach einem Home-Assistant-Neustart oder Sitzungsablauf eine erneute Reauthentifizierung.",
+          "totp_secret": "Base32-Secret aus deiner Authenticator-Einrichtung — ermöglicht automatische Re-Logins, keine Reauthentifizierung nach Neustarts. Code-Feld leer lassen, wenn du das Secret nutzt."
         }
       }
     },

--- a/custom_components/omv/translations/en.json
+++ b/custom_components/omv/translations/en.json
@@ -22,14 +22,14 @@
       },
       "totp": {
         "title": "Two-factor authentication",
-        "description": "Enter either a one-time verification code from your authenticator app, or your Base32 TOTP secret. When the secret is provided, it is stored so the integration can sign in again automatically (e.g. after a session expires or Home Assistant restarts).",
+        "description": "Sign in with either a one-time verification code or your TOTP secret. A code is valid for this login only — after a Home Assistant restart or session expiry you will need to reauthenticate. The secret is stored and lets the integration sign in again automatically.",
         "data": {
           "code": "Verification code",
           "totp_secret": "TOTP secret"
         },
         "data_description": {
-          "code": "6-digit one-time code. Leave empty when providing the TOTP secret instead.",
-          "totp_secret": "Optional: store the secret to enable automatic re-logins. Leave empty when providing a one-time code instead."
+          "code": "6-digit one-time code from your authenticator app. Requires reauthentication after a Home Assistant restart or session expiry.",
+          "totp_secret": "Base32 secret from your authenticator setup — enables automatic re-logins, no reauthentication after restarts. Leave the code field empty when using this."
         }
       }
     },

--- a/custom_components/omv/translations/en.json
+++ b/custom_components/omv/translations/en.json
@@ -22,9 +22,14 @@
       },
       "totp": {
         "title": "Two-factor authentication",
-        "description": "Enter the verification code from your authenticator app to finish signing in.",
+        "description": "Enter either a one-time verification code from your authenticator app, or your Base32 TOTP secret. When the secret is provided, it is stored so the integration can sign in again automatically (e.g. after a session expires or Home Assistant restarts).",
         "data": {
-          "code": "Verification code"
+          "code": "Verification code",
+          "totp_secret": "TOTP secret"
+        },
+        "data_description": {
+          "code": "6-digit one-time code. Leave empty when providing the TOTP secret instead.",
+          "totp_secret": "Optional: store the secret to enable automatic re-logins. Leave empty when providing a one-time code instead."
         }
       }
     },
@@ -32,7 +37,9 @@
       "invalid_auth": "Invalid credentials",
       "invalid_totp_code": "Invalid or expired verification code",
       "cannot_connect": "Cannot connect to OMV",
-      "unknown": "Unknown error"
+      "unknown": "Unknown error",
+      "invalid_totp_secret": "Invalid TOTP secret or the generated code was rejected",
+      "totp_code_or_secret_required": "Enter either a verification code or the TOTP secret (exactly one)"
     },
     "abort": {
       "already_configured": "This OpenMediaVault host is already configured. Use Reconfigure to update its host, port, SSL or two-factor authentication settings instead of adding it again.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,6 +30,7 @@ from custom_components.omv.const import (
     CONF_SELECTED_ZFS_POOLS,
     CONF_SMART_INTERVAL,
     CONF_SMART_POLLING_DISABLED,
+    CONF_TOTP_SECRET,
     DOMAIN,
 )
 from custom_components.omv.exceptions import OMVAuthError, OMVTwoFactorRequiredError
@@ -164,6 +165,256 @@ async def test_flow_totp_wrong_code(hass) -> None:
     assert result["type"] == "form"
     assert result["step_id"] == "totp"
     assert result["errors"]["base"] == "invalid_totp_code"
+
+
+TOTP_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+
+@pytest.mark.asyncio
+async def test_flow_totp_secret_verifies_and_stores_secret(hass) -> None:
+    """Providing the TOTP secret verifies a locally generated code and stores the secret."""
+    submit_mock = AsyncMock(return_value={"hostname": "nas"})
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_submit_two_factor_code",
+            new=submit_mock,
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+        patch("custom_components.omv.async_setup_entry", return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        assert result["step_id"] == "totp"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_TOTP_SECRET: TOTP_SECRET},
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_TOTP_SECRET] == TOTP_SECRET
+    submitted_code = submit_mock.await_args.args[0]
+    assert len(submitted_code) == 6 and submitted_code.isdigit()
+
+
+@pytest.mark.asyncio
+async def test_flow_totp_neither_code_nor_secret_shows_error(hass) -> None:
+    """Submitting the totp step without code and secret shows a validation error."""
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "totp"
+    assert result["errors"]["base"] == "totp_code_or_secret_required"
+
+
+@pytest.mark.asyncio
+async def test_flow_totp_both_code_and_secret_shows_error(hass) -> None:
+    """Submitting both a code and a secret shows the exactly-one validation error."""
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"code": "123456", CONF_TOTP_SECRET: TOTP_SECRET},
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "totp_code_or_secret_required"
+
+
+@pytest.mark.asyncio
+async def test_flow_totp_invalid_secret_shows_error(hass) -> None:
+    """A secret that is not valid Base32 is rejected without contacting OMV."""
+    submit_mock = AsyncMock()
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_submit_two_factor_code",
+            new=submit_mock,
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_TOTP_SECRET: "not-base32!!"},
+        )
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "invalid_totp_secret"
+    submit_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flow_totp_secret_rejected_by_omv_shows_error(hass) -> None:
+    """A well-formed secret whose generated code OMV rejects shows invalid_totp_secret."""
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_submit_two_factor_code",
+            new=AsyncMock(side_effect=OMVAuthError("Two-factor verification failed")),
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_TOTP_SECRET: TOTP_SECRET},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "totp"
+    assert result["errors"]["base"] == "invalid_totp_secret"
+
+
+@pytest.mark.asyncio
+async def test_flow_reauth_with_totp_secret_updates_entry(hass) -> None:
+    """Reauth with a TOTP secret stores it on the existing entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OMV (nas)",
+        unique_id="nas",
+        data=USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_submit_two_factor_code",
+            new=AsyncMock(return_value={"hostname": "nas"}),
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+        patch("custom_components.omv.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        assert result["step_id"] == "totp"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_TOTP_SECRET: TOTP_SECRET},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_TOTP_SECRET] == TOTP_SECRET
+
+
+@pytest.mark.asyncio
+async def test_flow_reauth_with_code_keeps_stored_totp_secret(hass) -> None:
+    """Reauthenticating with a one-time code must not drop a previously stored secret."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OMV (nas)",
+        unique_id="nas",
+        data={**USER_INPUT, CONF_TOTP_SECRET: TOTP_SECRET},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=OMVTwoFactorRequiredError("2FA required", challenge_kind="totp")),
+        ),
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_submit_two_factor_code",
+            new=AsyncMock(return_value={"hostname": "nas"}),
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+        patch("custom_components.omv.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"code": "123456"})
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_TOTP_SECRET] == TOTP_SECRET
+
+
+@pytest.mark.asyncio
+async def test_flow_reauth_stores_handoff_under_entry_unique_id(hass) -> None:
+    """The reauth hand-off is keyed by entry.unique_id, not the fresh hostname (Issue #55)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="OMV (nas)",
+        unique_id="nas",
+        data=USER_INPUT,
+    )
+    entry.add_to_hass(hass)
+
+    stored_keys: list[str] = []
+
+    with (
+        patch(
+            "custom_components.omv.config_flow.OMVAPI.async_connect",
+            new=AsyncMock(return_value={"hostname": "othernas"}),
+        ),
+        patch("custom_components.omv.config_flow.OMVAPI.async_close", new=AsyncMock()),
+        patch(
+            "custom_components.omv.config_flow.OMVConfigFlow._abort_if_unique_id_mismatch",
+            new=lambda self, **kwargs: None,
+        ),
+        patch(
+            "custom_components.omv.config_flow.session_handoff.store",
+            side_effect=lambda key, api, info: stored_keys.append(key),
+        ),
+        patch("custom_components.omv.async_setup_entry", return_value=True),
+    ):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    # Setup pops the hand-off under entry.unique_id — storing it under the
+    # freshly computed hostname ("othernas") would strand it forever.
+    assert stored_keys == ["nas"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -111,6 +111,137 @@ async def test_async_setup_entry_connects_fresh_without_handoff(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_multi_instance_handoffs_stay_separate(hass) -> None:
+    """Two entries with distinct unique_ids each pop only their own hand-off."""
+    entry1 = MockConfigEntry(
+        domain=DOMAIN,
+        title="OMV (nas1)",
+        unique_id="nas1",
+        data={**ENTRY_DATA, CONF_HOST: "192.0.2.10"},
+    )
+    entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        title="OMV (nas2)",
+        unique_id="nas2",
+        data={**ENTRY_DATA, CONF_HOST: "192.0.2.11"},
+    )
+    entry1.add_to_hass(hass)
+    entry2.add_to_hass(hass)
+
+    api1 = AsyncMock()
+    api2 = AsyncMock()
+    session_handoff.store("nas1", api1, {"hostname": "nas1", "version": "8.1.2-1"})
+    session_handoff.store("nas2", api2, {"hostname": "nas2", "version": "8.1.2-1"})
+
+    with (
+        patch(
+            "custom_components.omv.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=AssertionError("should not open a new OMV login")),
+        ),
+        patch("custom_components.omv.OMVDataUpdateCoordinator.async_init", new=AsyncMock()),
+        patch(
+            "custom_components.omv.OMVDataUpdateCoordinator._async_update_data",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        # Loading the component sets up every entry of the domain.
+        assert await hass.config_entries.async_setup(entry1.entry_id) is True
+        await hass.async_block_till_done()
+
+    assert entry1.runtime_data.api is api1
+    assert entry2.runtime_data.api is api2
+    assert session_handoff.pop("nas1") is None
+    assert session_handoff.pop("nas2") is None
+
+
+@pytest.mark.asyncio
+async def test_unload_closes_old_api_when_handoff_holds_new_instance(hass) -> None:
+    """After reauth/reconfigure the hand-off holds a NEW api — unload must close the old one."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    old_api = AsyncMock()
+    session_handoff.store("nas", old_api, {"hostname": "nas", "version": "8.1.2-1"})
+
+    with (
+        patch(
+            "custom_components.omv.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=AssertionError("should not open a new OMV login")),
+        ),
+        patch("custom_components.omv.OMVDataUpdateCoordinator.async_init", new=AsyncMock()),
+        patch(
+            "custom_components.omv.OMVDataUpdateCoordinator._async_update_data",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
+        assert entry.runtime_data.api is old_api
+
+        # Simulate a reauth flow that just stashed a brand-new authenticated
+        # session for the reload that follows this unload.
+        new_api = AsyncMock()
+        session_handoff.store("nas", new_api, {"hostname": "nas", "version": "8.1.2-1"})
+
+        assert await hass.config_entries.async_unload(entry.entry_id) is True
+
+    # The obsolete session must be closed (previously it leaked), while the
+    # handed-off replacement stays available for the reload.
+    old_api.async_close.assert_awaited_once()
+    new_api.async_close.assert_not_awaited()
+    popped = session_handoff.pop("nas")
+    assert popped is not None and popped[0] is new_api
+
+
+@pytest.mark.asyncio
+async def test_unload_keeps_api_open_when_handoff_holds_same_instance(hass) -> None:
+    """The options-reload hand-off holds the SAME api — unload must not close it."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    api = AsyncMock()
+    session_handoff.store("nas", api, {"hostname": "nas", "version": "8.1.2-1"})
+
+    with (
+        patch(
+            "custom_components.omv.OMVAPI.async_connect",
+            new=AsyncMock(side_effect=AssertionError("should not open a new OMV login")),
+        ),
+        patch("custom_components.omv.OMVDataUpdateCoordinator.async_init", new=AsyncMock()),
+        patch(
+            "custom_components.omv.OMVDataUpdateCoordinator._async_update_data",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
+        assert entry.runtime_data.api is api
+
+        # Simulate _async_update_listener stashing the still-live session for
+        # the immediate options reload.
+        session_handoff.store("nas", api, {"hostname": "nas", "version": "8.1.2-1"})
+
+        assert await hass.config_entries.async_unload(entry.entry_id) is True
+
+    api.async_close.assert_not_awaited()
+    popped = session_handoff.pop("nas")
+    assert popped is not None and popped[0] is api
+
+
+@pytest.mark.asyncio
 async def test_options_update_reuses_live_session_without_relogin(hass) -> None:
     """Changing an option must not force a fresh OMV login (and thus a 2FA challenge).
 

--- a/tests/test_omv_api.py
+++ b/tests/test_omv_api.py
@@ -217,6 +217,180 @@ async def test_submit_two_factor_code_wrong_code_raises_auth_error(
     await api.async_close()
 
 
+TOTP_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+
+@pytest.mark.asyncio
+async def test_connect_with_totp_secret_answers_challenge_automatically(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A configured TOTP secret answers the login challenge via Session.verify."""
+    seen_bodies: list[dict] = []
+
+    def rpc_callback(url, **kwargs):
+        body = kwargs.get("json") or {}
+        seen_bodies.append(body)
+        if body["method"] == "login":
+            return CallbackResult(
+                status=200,
+                payload={
+                    "response": {
+                        "status": "challengeRequired",
+                        "challenge": {"kind": "totp"},
+                        "username": "admin",
+                    },
+                    "error": None,
+                },
+            )
+        if body["method"] == "verify":
+            return CallbackResult(
+                status=200,
+                payload={
+                    "response": {
+                        "status": "authenticated",
+                        "sessionid": "session123",
+                        "username": "admin",
+                        "permissions": {},
+                    },
+                    "error": None,
+                },
+            )
+        return CallbackResult(
+            status=200,
+            payload={"response": {"version": "8.5.0", "hostname": "nas"}, "error": None},
+        )
+
+    mock_aiohttp.post("http://192.168.1.1:80/rpc.php", callback=rpc_callback, repeat=True)
+
+    api = OMVAPI("192.168.1.1", "admin", "pass", totp_secret=TOTP_SECRET)
+    info = await api.async_connect()
+
+    assert info["hostname"] == "nas"
+    assert api._session_id == "session123"
+    verify_bodies = [body for body in seen_bodies if body["method"] == "verify"]
+    assert len(verify_bodies) == 1
+    code = verify_bodies[0]["params"]["code"]
+    assert isinstance(code, str) and len(code) == 6 and code.isdigit()
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_session_expiry_auto_relogin_with_totp_secret(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Session expiry on a 2FA account re-logins via the stored secret (Issue #55)."""
+    # Initial connect: legacy login (no challenge yet) + System.getInformation.
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={"response": {"authenticated": True, "sessionid": "session123"}, "error": None},
+    )
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={"response": {"version": "8.5.0", "hostname": "nas"}, "error": None},
+    )
+    # RPC fails with session-expired, fresh login is challenged, verify succeeds,
+    # the original RPC is retried successfully.
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={"response": None, "error": {"code": 5001, "message": "expired"}},
+    )
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={
+            "response": {
+                "status": "challengeRequired",
+                "challenge": {"kind": "totp"},
+                "username": "admin",
+            },
+            "error": None,
+        },
+    )
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={
+            "response": {
+                "status": "authenticated",
+                "sessionid": "session456",
+                "username": "admin",
+                "permissions": {},
+            },
+            "error": None,
+        },
+    )
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={"response": {"cpuUtilization": 42}, "error": None},
+    )
+
+    api = OMVAPI("192.168.1.1", "admin", "pass", totp_secret=TOTP_SECRET)
+    await api.async_connect()
+
+    response = await api.async_call("System", "getInformation")
+
+    assert response["cpuUtilization"] == 42
+    assert api._session_id == "session456"
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_wrong_totp_secret_raises_auth_error(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """All candidate codes rejected (wrong secret) surfaces as OMVAuthError."""
+
+    def rpc_callback(url, **kwargs):
+        body = kwargs.get("json") or {}
+        if body["method"] == "login":
+            return CallbackResult(
+                status=200,
+                payload={
+                    "response": {
+                        "status": "challengeRequired",
+                        "challenge": {"kind": "totp"},
+                        "username": "admin",
+                    },
+                    "error": None,
+                },
+            )
+        return CallbackResult(
+            status=401,
+            payload={"response": None, "error": {"code": 0, "message": "Challenge verification failed."}},
+        )
+
+    mock_aiohttp.post("http://192.168.1.1:80/rpc.php", callback=rpc_callback, repeat=True)
+
+    api = OMVAPI("192.168.1.1", "admin", "pass", totp_secret=TOTP_SECRET)
+    with pytest.raises(OMVAuthError) as excinfo:
+        await api.async_connect()
+    # Must NOT be the two-factor-required variant — a secret was configured,
+    # it just did not work; a reauth flow (not a dead-end) is the right outcome.
+    assert not isinstance(excinfo.value, OMVTwoFactorRequiredError)
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_connect_without_totp_secret_still_raises_two_factor_error(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """Without a stored secret the challenge behaviour is unchanged."""
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={
+            "response": {
+                "status": "challengeRequired",
+                "challenge": {"kind": "totp"},
+                "username": "admin",
+            },
+            "error": None,
+        },
+    )
+
+    api = OMVAPI("192.168.1.1", "admin", "pass")
+    with pytest.raises(OMVTwoFactorRequiredError):
+        await api.async_connect()
+    await api.async_close()
+
+
 @pytest.mark.asyncio
 async def test_login_opaque_401_raises_connection_error(
     mock_aiohttp: aioresponses,

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -1,0 +1,82 @@
+"""Tests for the stdlib-only RFC 6238 TOTP helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.omv import totp
+
+# RFC 6238 Appendix B test secret: ASCII "12345678901234567890" in Base32.
+RFC_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "expected"),
+    [
+        # RFC 6238 Appendix B SHA-1 vectors, truncated to 6 digits.
+        (59, "287082"),
+        (1111111109, "081804"),
+        (1111111111, "050471"),
+        (1234567890, "005924"),
+        (2000000000, "279037"),
+        (20000000000, "353130"),
+    ],
+)
+def test_generate_code_rfc6238_vectors(timestamp: int, expected: str) -> None:
+    """Codes match the RFC 6238 SHA-1 reference vectors."""
+    assert totp.generate_code(RFC_SECRET, timestamp) == expected
+
+
+def test_generate_code_uses_current_time_by_default() -> None:
+    """Without a timestamp the code matches the current 30s window."""
+    import time
+
+    now = time.time()
+    assert totp.generate_code(RFC_SECRET) in {
+        totp.generate_code(RFC_SECRET, now),
+        # Guard against the window flipping between the two calls.
+        totp.generate_code(RFC_SECRET, now + totp.TIME_STEP),
+    }
+
+
+@pytest.mark.parametrize(
+    "messy",
+    [
+        "gezdgnbvgy3tqojqgezdgnbvgy3tqojq",  # lower-case
+        "GEZD GNBV GY3T QOJQ GEZD GNBV GY3T QOJQ",  # grouped with spaces
+        "GEZD-GNBV-GY3T-QOJQ-GEZD-GNBV-GY3T-QOJQ",  # grouped with dashes
+    ],
+)
+def test_generate_code_tolerates_secret_formatting(messy: str) -> None:
+    """Common authenticator-app secret formats are normalized before decoding."""
+    assert totp.generate_code(messy, 59) == "287082"
+
+
+def test_generate_code_pads_missing_base32_padding() -> None:
+    """Secrets without '=' padding are padded to a multiple of 8 chars."""
+    unpadded = "GEZDGNBVGY3TQOJQGEZDGNBVGY"  # 26 chars -> needs padding
+    assert totp.generate_code(unpadded, 59) == totp.generate_code(unpadded + "======", 59)
+
+
+@pytest.mark.parametrize(
+    ("secret", "valid"),
+    [
+        (RFC_SECRET, True),
+        ("gezd gnbv gy3t qojq gezd gnbv gy3t qojq", True),
+        ("", False),
+        ("   ", False),
+        ("not-base32!!", False),
+        ("1nvalid8", False),  # '1' is not in the Base32 alphabet
+    ],
+)
+def test_is_valid_secret(secret: str, valid: bool) -> None:
+    """is_valid_secret accepts decodable secrets and rejects garbage."""
+    assert totp.is_valid_secret(secret) is valid
+
+
+def test_generate_code_invalid_secret_raises_value_error() -> None:
+    """Invalid Base32 input raises ValueError instead of a cryptic binascii error."""
+    with pytest.raises(ValueError):
+        totp.generate_code("not-base32!!", 59)
+    with pytest.raises(ValueError):
+        totp.generate_code("", 59)


### PR DESCRIPTION
Closes #55

## Problem

On setups with two TOTP-enabled OMV instances, the second instance drops into a failed state (`challenge kind='totp'`) ~1 minute after a successful reauth. Root causes (verified):

1. **No way to answer re-login challenges.** On session expiry (5001/5002 or HTTP 401) `OMVAPI.async_call` re-runs `Session.login`; OMV 8.5+ challenges every fresh login for 2FA accounts. The integration stored no TOTP secret, so every session expiry and every HA restart ended in `ConfigEntryAuthFailed` → reauth loop.
2. **Handoff keying mismatch.** The config flow stored the authenticated-session hand-off under the freshly computed hostname, while `async_setup_entry` pops it by `entry.unique_id` — divergence strands or crosses hand-offs in multi-instance setups.
3. **Session leak.** After reauth/reconfigure the hand-off holds a *new* API instance, but the `has_pending` guard in `async_unload_entry` kept the *old* instance open — its OMV session leaked.

## Changes

- **`totp.py` (new, stdlib-only, analogous to `wol.py`):** RFC 6238 code generator (Base32-tolerant normalization, HMAC-SHA1, 30 s window, 6 digits) with `generate_code()` / `is_valid_secret()`.
- **`omv_api.py`:** optional `totp_secret`; `_async_login()` answers a `totp` challenge automatically via `Session.verify {"code": ...}` on the same cookie-bound session, retrying the ±30 s neighbour windows once each for clock skew. Without a secret, behaviour is unchanged (`OMVTwoFactorRequiredError`).
- **`config_flow.py`:** the `totp` step accepts either a one-time code **or** the TOTP secret (exactly one; errors `totp_code_or_secret_required`, `invalid_totp_secret`). A provided secret is verified against OMV and stored in `entry.data`; a later code-only reauth keeps a previously stored secret. Applies to user, reauth and reconfigure sources (shared step).
- **Handoff keying:** reauth/reconfigure hand-offs are stored under `entry.unique_id` (the key setup pops), new entries keep hostname (identical there).
- **Session leak:** `async_unload_entry` closes the old API unless the pending hand-off holds exactly that instance (options-reload case) — new helper `session_handoff.pending_api_is()`.
- **Coordinator:** `ConfigEntryAuthFailed` message now distinguishes an unanswerable 2FA challenge (no stored secret) from other auth failures.
- **Security:** the TOTP secret lives in `entry.data` (HA storage, same confidentiality class as the password) and is redacted in diagnostics (`TO_REDACT`), protecting against secret disclosure through diagnostics dumps.

## Tests

- `test_totp.py`: RFC 6238 SHA-1 vectors, secret normalization/validation.
- `test_omv_api.py`: auto-relogin sequence (RPC → 5001 → challenged login → verify → retried RPC), wrong secret → `OMVAuthError` (not the 2FA-required variant), no secret → unchanged `OMVTwoFactorRequiredError`.
- `test_config_flow.py`: secret path (user + reauth), neither/both inputs, invalid secret, OMV-rejected secret, code-only reauth keeps stored secret, hand-off keyed by `entry.unique_id`.
- `test_init.py`: multi-instance hand-offs stay separate; unload closes the old API after reauth but keeps the options-reload instance open.

`pytest` 340 passed · `ruff` clean · `mypy` no new errors (baseline untouched).

## Verification note

#55 is not fully reproducible locally (no second TOTP-enabled OMV available). The failure chain is covered by the new unit/flow tests; requesting verification by the reporter on the issue — including whether the second instance's WebGUI session timeout (~60 s pattern) matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)