### PR TITLE
fix(auth): stop OMV login-notification email spam (Issue #62)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -22,6 +22,11 @@ env:
 jobs:
   smoke:
     name: Deploy + REST verify on Pi
+    # Dependabot pull_request runs cannot read Actions secrets (they use a
+    # separate Dependabot secret store), so the Infisical fetch would fail with
+    # "Missing universal auth credentials". A live Pi deploy adds no value for a
+    # dependency/actions bump anyway — skip the job so it reports neutrally.
+    if: github.actor != 'dependabot[bot]'
     # Ephemeral ARC runner (org-scoped, kubernetes containerMode) — see
     # homelab kubernetes/apps/arc-runners. Fresh pod per run, nothing persists.
     runs-on: k8s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- OMV no longer sends a "login from browser" notification email on every re-login / HA restart (Issue #62). OMV suppresses repeat login notifications when the requesting browser resends the persistent `OPENMEDIAVAULT-LOGIN-*` dedup cookie it sets on first login; the integration now captures that cookie, persists its name per config entry in an HA `Store`, and replays it into the aiohttp cookie jar on every session (re)creation and after HA restarts (`omv_api.py`, `__init__.py`, `const.py`). The first login of a fresh setup still notifies, as intended.
+- HA Smoke Test no longer fails on Dependabot PRs. Dependabot `pull_request` runs cannot read Actions secrets, so the Infisical credential fetch always failed with "Missing universal auth credentials"; the deploy/verify job is now skipped for `dependabot[bot]` (`.github/workflows/smoke-test.yml`).
+
 ## [2.6.3] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.6.4] - 2026-07-14
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Never hard-code English `_attr_name`. Use `translation_key` + `_attr_translation
 
 - **`CookieJar(unsafe=True)`** is required for IP-based hosts — without it the session cookie is silently dropped and subsequent RPCs fail with a spurious auth error.
 - `OMVAPI.async_call()` auto-re-authenticates on session expiry (error codes 5001/5002).
+- **Login-notification dedup cookie (Issue #62):** on the first login from a new browser, OMV sends a "login from browser" security email and sets a persistent 60-day cookie `OPENMEDIAVAULT-LOGIN-<hex(bcrypt(username))>` (only the cookie *name* is checked — `session.inc::isFirstLoginFromBrowser`). `OMVAPI` captures that cookie name, `__init__.py` persists it per entry in an HA `Store`, and `_inject_login_cookie()` replays it into every (re)created cookie jar so OMV suppresses repeat emails on re-logins and after HA restarts. Do not drop this cookie when recreating the aiohttp session.
 - All calls go through an async lock — no concurrent requests to the same session.
 - OMV size fields can arrive as bare numeric strings (no unit) — treat them as **bytes**, not GB.
 

--- a/custom_components/omv/__init__.py
+++ b/custom_components/omv/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.storage import Store
 
 from . import session_handoff
 from .const import (
@@ -28,6 +29,8 @@ from .const import (
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    LOGIN_COOKIE_STORAGE_KEY,
+    LOGIN_COOKIE_STORAGE_VERSION,
     PLATFORMS,
 )
 from .coordinator import OMVDataUpdateCoordinator
@@ -39,6 +42,50 @@ from .services import async_setup_services
 _LOGGER = logging.getLogger(__name__)
 
 type OMVConfigEntry = ConfigEntry[OMVDataUpdateCoordinator]
+
+
+def _login_cookie_store(hass: HomeAssistant, entry: OMVConfigEntry) -> Store:
+    """Return the per-entry Store for the OMV login-notification cookie name.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The config entry the cookie belongs to.
+
+    Returns:
+        A :class:`Store` keyed by the entry id (Issue #62).
+    """
+    return Store(
+        hass,
+        LOGIN_COOKIE_STORAGE_VERSION,
+        f"{DOMAIN}.{LOGIN_COOKIE_STORAGE_KEY}.{entry.entry_id}",
+    )
+
+
+async def _async_persist_login_cookie(
+    hass: HomeAssistant,
+    entry: OMVConfigEntry,
+    api: OMVAPI,
+) -> None:
+    """Persist the OMV login-notification dedup cookie name for reuse.
+
+    Stores the ``OPENMEDIAVAULT-LOGIN-*`` cookie name OMV issued on first
+    login so a later HA restart can replay it and OMV does not re-send the
+    login-notification email (Issue #62). No-op when no cookie has been
+    captured yet or the stored value is already up to date.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The config entry being set up.
+        api: The live OMV API client.
+    """
+    name = api.get_login_cookie_name()
+    if not isinstance(name, str) or not name:
+        return
+    store = _login_cookie_store(hass, entry)
+    stored = await store.async_load()
+    if isinstance(stored, dict) and stored.get("cookie_name") == name:
+        return
+    await store.async_save({"cookie_name": name})
 
 
 def _register_registry_cleanup_listener(
@@ -148,6 +195,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool:
             totp_secret=entry.data.get(CONF_TOTP_SECRET),
         )
 
+        # Replay a previously captured OMV login-notification dedup cookie so
+        # the first login after an HA restart does not trigger another
+        # security-notification email (Issue #62).
+        stored_cookie = await _login_cookie_store(hass, entry).async_load()
+        if isinstance(stored_cookie, dict) and stored_cookie.get("cookie_name"):
+            api.set_login_cookie_name(stored_cookie["cookie_name"])
+
         try:
             system_info = await api.async_connect()
         except OMVAuthError as err:
@@ -165,6 +219,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool:
     )
     await coordinator.async_init(system_info)
     await coordinator.async_config_entry_first_refresh()
+    await _async_persist_login_cookie(hass, entry, api)
     entry.runtime_data = coordinator
     await _async_cleanup_stale_registry_entries(hass, entry, coordinator)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -190,6 +245,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool
         if not session_handoff.pending_api_is(entry.unique_id, entry.runtime_data.api):
             await entry.runtime_data.api.async_close()
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> None:
+    """Remove the persisted OMV login-notification cookie on entry deletion.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The config entry being removed.
+    """
+    await _login_cookie_store(hass, entry).async_remove()
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: OMVConfigEntry) -> None:

--- a/custom_components/omv/const.py
+++ b/custom_components/omv/const.py
@@ -21,6 +21,12 @@ DEFAULT_VERIFY_SSL = True
 # Optionales TOTP-Secret (entry.data) für automatische Re-Logins bei 2FA (Issue #55)
 CONF_TOTP_SECRET = "totp_secret"
 
+# Persistenz des OMV Login-Notification-Dedup-Cookies (Issue #62): der
+# OPENMEDIAVAULT-LOGIN-*-Cookie-Name wird pro Config-Entry in einem HA-Store
+# abgelegt, damit OMV nach HA-Neustarts keine erneute Login-Mail schickt.
+LOGIN_COOKIE_STORAGE_VERSION = 1
+LOGIN_COOKIE_STORAGE_KEY = "login_cookie"
+
 # Optionsschlüssel für auswählbare Ressourcen
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_REBOOT_REPAIR_DISABLED = "reboot_repair_disabled"

--- a/custom_components/omv/manifest.json
+++ b/custom_components/omv/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/slybase/homeassistant-openmediavault/issues",
     "requirements": [],
-    "version": "2.6.3"
+    "version": "2.6.4"
 }

--- a/custom_components/omv/omv_api.py
+++ b/custom_components/omv/omv_api.py
@@ -20,6 +20,15 @@ from .exceptions import (
 
 _LOGGER = logging.getLogger(__name__)
 _SESSION_EXPIRED_CODES = {5001, 5002}
+# OMV sets a persistent (60-day) browser-dedup cookie named
+# ``OPENMEDIAVAULT-LOGIN-<hex(bcrypt(username))>`` on the first login from a
+# given browser and emails a security notification only when it is absent
+# (see openmediavault ``rpc/session.inc::handleSuccessfulLogin``). Persisting
+# and replaying this cookie makes OMV treat the integration like the same
+# browser, so the login-notification email is not re-sent on every re-login /
+# HA restart (Issue #62). Only the cookie *name* is checked by OMV, not its
+# value.
+_LOGIN_NOTIFICATION_COOKIE_PREFIX = "OPENMEDIAVAULT-LOGIN-"
 _REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)
 _INVALID_LOGIN_MESSAGES = (
     "incorrect username or password",
@@ -54,6 +63,7 @@ class OMVAPI:
         self._session_id: str | None = None
         self._session: aiohttp.ClientSession | None = None
         self._lock = asyncio.Lock()
+        self._login_cookie_name: str | None = None
 
     def set_totp_secret(self, totp_secret: str | None) -> None:
         """Set the TOTP secret used to answer 2FA challenges automatically.
@@ -67,6 +77,31 @@ class OMVAPI:
                 automatic challenge answering.
         """
         self._totp_secret = totp_secret
+
+    def get_login_cookie_name(self) -> str | None:
+        """Return the OMV login-notification dedup cookie name, if known.
+
+        Returns:
+            The ``OPENMEDIAVAULT-LOGIN-*`` cookie name captured from a previous
+            successful login, or ``None`` if it has not been observed yet.
+            Used by the config-entry setup to persist the name across HA
+            restarts (Issue #62).
+        """
+        return self._login_cookie_name
+
+    def set_login_cookie_name(self, name: str | None) -> None:
+        """Seed the OMV login-notification dedup cookie name.
+
+        Called before :meth:`async_connect` with a value persisted from a
+        prior HA run so the very first ``Session.login`` after a restart
+        replays the cookie and OMV suppresses the login-notification email
+        (Issue #62). The cookie is injected into the jar on the next session
+        (re)creation via :meth:`_inject_login_cookie`.
+
+        Args:
+            name: The ``OPENMEDIAVAULT-LOGIN-*`` cookie name, or ``None``.
+        """
+        self._login_cookie_name = name
 
     @property
     def base_url(self) -> str:
@@ -114,13 +149,60 @@ class OMVAPI:
         return any(fragment in lowered for fragment in _INVALID_LOGIN_MESSAGES)
 
     async def _async_ensure_session(self) -> None:
-        """Create or recreate the aiohttp session."""
+        """Create or recreate the aiohttp session.
+
+        Re-injects the OMV login-notification dedup cookie (if known) into the
+        fresh cookie jar so recreating the session — e.g. on the connection
+        error retry path — does not drop it and cause OMV to re-send the login
+        notification email (Issue #62).
+        """
         if self._session and not self._session.closed:
             await self._session.close()
         self._session = aiohttp.ClientSession(
             cookie_jar=aiohttp.CookieJar(unsafe=True),
             timeout=_REQUEST_TIMEOUT,
         )
+        self._inject_login_cookie()
+
+    def _inject_login_cookie(self) -> None:
+        """Replay the OMV login-notification dedup cookie into the current jar.
+
+        OMV only checks the cookie *name* (``OPENMEDIAVAULT-LOGIN-*``), so a
+        placeholder value is sufficient. The cookie is added without a
+        ``SameSite`` attribute so aiohttp always sends it on the
+        ``POST /rpc.php`` requests, independent of same-site heuristics that
+        could otherwise suppress OMV's own ``SameSite=Strict`` cookie
+        (Issue #62).
+        """
+        if not self._login_cookie_name or not self._session or self._session.closed:
+            return
+        self._session.cookie_jar.update_cookies(
+            {self._login_cookie_name: "1"},
+            response_url=URL(self.base_url),
+        )
+
+    def _capture_login_cookie(self) -> None:
+        """Capture the OMV login-notification dedup cookie name from the jar.
+
+        Scans the active cookie jar for a cookie whose name starts with
+        :data:`_LOGIN_NOTIFICATION_COOKIE_PREFIX` (set by OMV on the first
+        login from a new browser) and records it so it can be persisted and
+        replayed on later logins / HA restarts (Issue #62). Existing values
+        are only overwritten when OMV issued a (new) cookie.
+        """
+        if not self._session or self._session.closed:
+            return
+        cookies = self._session.cookie_jar.filter_cookies(URL(f"{self.base_url}/rpc.php"))
+        for name in cookies:
+            if name.upper().startswith(_LOGIN_NOTIFICATION_COOKIE_PREFIX):
+                self._login_cookie_name = name
+                _LOGGER.debug(
+                    "Captured OMV login-notification cookie [%s] host=%r name=%r",
+                    self._source,
+                    self._host,
+                    name,
+                )
+                return
 
     async def _async_login(self) -> None:
         """Authenticate with OMV and initialize the session cookie jar.
@@ -178,6 +260,7 @@ class OMVAPI:
                     session_id = data.get("sessionid")
                     if isinstance(session_id, str) and session_id:
                         self._session_id = session_id
+                    self._capture_login_cookie()
                     _LOGGER.debug(
                         "Automatically answered OMV TOTP challenge for %s [%s]; sessionid_present=%s",
                         self._host,
@@ -195,6 +278,7 @@ class OMVAPI:
         if isinstance(session_id, str) and session_id:
             self._session_id = session_id
 
+        self._capture_login_cookie()
         _LOGGER.debug(
             "Successfully authenticated with OMV at %s [%s]; sessionid_present=%s cookie_names=%s",
             self._host,
@@ -290,6 +374,7 @@ class OMVAPI:
         if isinstance(session_id, str) and session_id:
             self._session_id = session_id
 
+        self._capture_login_cookie()
         response = await self.async_call("System", "getInformation")
         return response if isinstance(response, dict) else {}
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.const import (
@@ -15,7 +15,11 @@ from homeassistant.const import (
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.omv import session_handoff
+from custom_components.omv import (
+    _async_persist_login_cookie,
+    _login_cookie_store,
+    session_handoff,
+)
 from custom_components.omv.const import CONF_SCAN_INTERVAL, DOMAIN
 
 ENTRY_DATA = {
@@ -37,13 +41,51 @@ def _make_entry() -> MockConfigEntry:
     )
 
 
+def _mock_handoff_api() -> AsyncMock:
+    """Return a mock OMV API suitable for session-handoff tests.
+
+    ``get_login_cookie_name`` is a synchronous stub returning ``None`` so the
+    login-cookie persistence in ``async_setup_entry`` is a no-op and does not
+    try to serialise an ``AsyncMock`` coroutine (Issue #62).
+    """
+    api = AsyncMock()
+    api.get_login_cookie_name = MagicMock(return_value=None)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_persist_login_cookie_writes_captured_name(hass) -> None:
+    """A captured OMV login-dedup cookie name is written to the entry store (Issue #62)."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    api = _mock_handoff_api()
+    api.get_login_cookie_name = MagicMock(return_value="OPENMEDIAVAULT-LOGIN-xyz")
+
+    await _async_persist_login_cookie(hass, entry, api)
+
+    stored = await _login_cookie_store(hass, entry).async_load()
+    assert stored == {"cookie_name": "OPENMEDIAVAULT-LOGIN-xyz"}
+
+
+@pytest.mark.asyncio
+async def test_persist_login_cookie_noop_without_name(hass) -> None:
+    """Nothing is stored when no OMV login-dedup cookie has been captured (Issue #62)."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    api = _mock_handoff_api()  # get_login_cookie_name() -> None
+
+    await _async_persist_login_cookie(hass, entry, api)
+
+    assert await _login_cookie_store(hass, entry).async_load() is None
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_reuses_handed_off_session(hass) -> None:
     """A session stashed by the config flow is reused instead of a fresh OMV login."""
     entry = _make_entry()
     entry.add_to_hass(hass)
 
-    handed_off_api = AsyncMock()
+    handed_off_api = _mock_handoff_api()
     system_info = {"hostname": "nas", "version": "8.1.2-1"}
     session_handoff.store("nas", handed_off_api, system_info)
 
@@ -128,8 +170,8 @@ async def test_async_setup_entry_multi_instance_handoffs_stay_separate(hass) -> 
     entry1.add_to_hass(hass)
     entry2.add_to_hass(hass)
 
-    api1 = AsyncMock()
-    api2 = AsyncMock()
+    api1 = _mock_handoff_api()
+    api2 = _mock_handoff_api()
     session_handoff.store("nas1", api1, {"hostname": "nas1", "version": "8.1.2-1"})
     session_handoff.store("nas2", api2, {"hostname": "nas2", "version": "8.1.2-1"})
 
@@ -165,7 +207,7 @@ async def test_unload_closes_old_api_when_handoff_holds_new_instance(hass) -> No
     entry = _make_entry()
     entry.add_to_hass(hass)
 
-    old_api = AsyncMock()
+    old_api = _mock_handoff_api()
     session_handoff.store("nas", old_api, {"hostname": "nas", "version": "8.1.2-1"})
 
     with (
@@ -208,7 +250,7 @@ async def test_unload_keeps_api_open_when_handoff_holds_same_instance(hass) -> N
     entry = _make_entry()
     entry.add_to_hass(hass)
 
-    api = AsyncMock()
+    api = _mock_handoff_api()
     session_handoff.store("nas", api, {"hostname": "nas", "version": "8.1.2-1"})
 
     with (

--- a/tests/test_omv_api.py
+++ b/tests/test_omv_api.py
@@ -580,3 +580,92 @@ async def test_async_apply_config_sends_required_params(
     assert body["method"] == "applyChanges"
     assert body["params"] == {"modules": [], "force": False}
     await api.async_close()
+
+
+def _login_cookie_names(api: OMVAPI) -> list[str]:
+    """Return the cookie names currently stored for the OMV RPC endpoint."""
+    assert api._session is not None
+    cookies = api._session.cookie_jar.filter_cookies(URL(f"{api.base_url}/rpc.php"))
+    return sorted(cookies.keys())
+
+
+@pytest.mark.asyncio
+async def test_get_set_login_cookie_name_roundtrip() -> None:
+    """The login-notification cookie name getter/setter round-trips (Issue #62)."""
+    api = OMVAPI("192.168.1.1", "admin", "pass")
+    assert api.get_login_cookie_name() is None
+    api.set_login_cookie_name("OPENMEDIAVAULT-LOGIN-abcd")
+    assert api.get_login_cookie_name() == "OPENMEDIAVAULT-LOGIN-abcd"
+
+
+@pytest.mark.asyncio
+async def test_capture_login_cookie_records_prefixed_cookie() -> None:
+    """_capture_login_cookie records the OMV login-dedup cookie, ignoring others."""
+    api = OMVAPI("192.168.1.1", "admin", "pass")
+    await api._async_ensure_session()
+    assert api._session is not None
+    # Simulate what real aiohttp does when OMV sends the Set-Cookie header on
+    # the first login from a new browser, plus an unrelated session cookie.
+    api._session.cookie_jar.update_cookies(
+        {
+            "X-OPENMEDIAVAULT-SESSIONID": "sess-value",
+            "OPENMEDIAVAULT-LOGIN-deadbeef": "dune-quote",
+        },
+        response_url=URL("http://192.168.1.1:80/rpc.php"),
+    )
+
+    api._capture_login_cookie()
+
+    assert api.get_login_cookie_name() == "OPENMEDIAVAULT-LOGIN-deadbeef"
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_reinjects_login_cookie() -> None:
+    """Recreating the session replays the login-dedup cookie so it survives.
+
+    The connection-error retry path recreates the aiohttp session; without
+    re-injection the OMV login-notification cookie would be lost and OMV would
+    email again on the next login (Issue #62).
+    """
+    api = OMVAPI("192.168.1.1", "admin", "pass")
+    api.set_login_cookie_name("OPENMEDIAVAULT-LOGIN-seed")
+
+    await api._async_ensure_session()
+    assert "OPENMEDIAVAULT-LOGIN-seed" in _login_cookie_names(api)
+
+    # A second recreation (as happens during connection-error recovery) must
+    # still carry the cookie.
+    await api._async_ensure_session()
+    assert "OPENMEDIAVAULT-LOGIN-seed" in _login_cookie_names(api)
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_seeded_login_cookie_present_for_first_login(
+    mock_aiohttp: aioresponses,
+) -> None:
+    """A persisted cookie name is replayed into the jar before the first login.
+
+    This is what suppresses OMV's repeated login-notification email after an
+    HA restart: the cookie is already in the jar when ``Session.login`` is
+    sent (Issue #62).
+    """
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={"response": {"authenticated": True, "sessionid": "session123"}, "error": None},
+    )
+    mock_aiohttp.post(
+        "http://192.168.1.1:80/rpc.php",
+        payload={"response": {"version": "8.1.2", "hostname": "nas"}, "error": None},
+    )
+
+    api = OMVAPI("192.168.1.1", "admin", "pass")
+    api.set_login_cookie_name("OPENMEDIAVAULT-LOGIN-restored")
+    await api.async_connect()
+
+    # After connect the restored cookie is still in the jar (was sent with the
+    # login request) and remains captured for persistence.
+    assert "OPENMEDIAVAULT-LOGIN-restored" in _login_cookie_names(api)
+    assert api.get_login_cookie_name() == "OPENMEDIAVAULT-LOGIN-restored"
+    await api.async_close()


### PR DESCRIPTION
## Problem

OMV sends a "login from browser" security email on **every** `Session.login` unless the requesting browser resends the persistent 60-day cookie `OPENMEDIAVAULT-LOGIN-<hex(bcrypt(username))>` that OMV sets on first login (only the cookie **name** is checked — see [`session.inc::isFirstLoginFromBrowser`](https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/var/www/openmediavault/rpc/session.inc)).

The integration held the aiohttp cookie jar in memory only, so the dedup cookie was lost:
- **on every HA restart** → one email per restart,
- **whenever the session was recreated** (connection-error retry) and on repeated re-logins → an email roughly every ~5 min while the OMV session kept expiring.

Closes #62.

## Fix

Behave like a persistent browser: capture the `OPENMEDIAVAULT-LOGIN-*` cookie name after login, persist it per config entry in an HA `Store`, and replay it into every (re)created cookie jar and **before** the first login after a restart, so OMV's own 60-day dedup suppresses repeat notifications.

The **first** login of a fresh setup (or after a username/password change or the 60-day expiry) still notifies — that is the intended security behavior; the cookie is never forged proactively.

### Changed
- `omv_api.py` — capture (`_capture_login_cookie`) / replay (`_inject_login_cookie`) the cookie; getter/setter; re-inject on `_async_ensure_session`.
- `__init__.py` — persist/seed the cookie name via `Store`; cleanup on `async_remove_entry`.
- `const.py` — storage constants.
- Tests: 6 new (capture, re-inject across session recreation, seed replay, getter/setter, Store persistence + no-op).

## Testing
- `pytest tests -q` → 364 passed
- `ruff check` clean; no new mypy errors in changed files
- This PR runs the HA smoke test against the Pi to confirm entities stay available with the new login flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)