### PR TITLE
fix(update): stop treating a failed apt-get/dpkg run as a successful install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.6.7] - 2026-08-04
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- The update-entity install action no longer reports success when the OMV-side `apt-get`/`dpkg` command itself failed (e.g. a host with an interrupted dpkg state). `Exec.isRunning` returns HTTP 500 both when the bgproc status file was cleaned up after a successful run and when the underlying command failed; only the former is now treated as "completed" — the latter's real error message is surfaced to HA instead of being silently swallowed (`update.py`).
+
 ## [2.6.6] - 2026-08-04
 
 ### Fixed

--- a/custom_components/omv/manifest.json
+++ b/custom_components/omv/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/slybase/homeassistant-openmediavault/issues",
     "requirements": [],
-    "version": "2.6.6"
+    "version": "2.6.7"
 }

--- a/custom_components/omv/update.py
+++ b/custom_components/omv/update.py
@@ -277,10 +277,19 @@ class OMVUpdateEntity(OMVEntity, UpdateEntity):
         install as failed.  If *filename* is not a string the call is silently
         skipped (defensive guard for unexpected RPC responses).
 
-        OMV deletes the bgproc status file as soon as the process completes.
-        Any subsequent Exec.isRunning call then returns HTTP 500 because the
-        file no longer exists.  HTTP 500 is therefore treated as "process
-        finished successfully" rather than a real connection error.
+        OMV deletes the bgproc status file as soon as the process completes,
+        whether it succeeded or failed. Any subsequent Exec.isRunning call
+        then returns HTTP 500 because the file no longer exists. A bare
+        HTTP 500 is therefore normally treated as "process finished" rather
+        than a real connection error.
+
+        However, when the underlying command itself failed (e.g. apt-get
+        exiting non-zero), OMV's 500 response body still carries the actual
+        error message ("Failed to execute command ... with exit code ...").
+        That case must NOT be swallowed as success — it is re-raised so the
+        real failure (e.g. a broken dpkg state requiring manual
+        `dpkg --configure -a` on the host) surfaces to HA instead of the
+        install silently completing with nothing actually upgraded.
 
         Args:
             filename: The bgproc status filename returned by an OMV execBgProc
@@ -295,7 +304,7 @@ class OMVUpdateEntity(OMVEntity, UpdateEntity):
                     "Exec", "isRunning", {"filename": filename}, max_retries=0
                 )
             except OMVConnectionError as err:
-                if "HTTP 500" in str(err):
+                if "HTTP 500" in str(err) and "Failed to execute command" not in str(err):
                     # OMV deletes the bgproc status file once the process
                     # completes; the next Exec.isRunning call then returns
                     # HTTP 500 because the file is gone — treat as done.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -179,6 +179,39 @@ async def test_async_install_treats_http500_from_bgproc_as_done(coordinator) -> 
 
 
 @pytest.mark.asyncio
+async def test_async_install_raises_when_bgproc_command_itself_failed(coordinator) -> None:
+    """Test that an HTTP 500 carrying a real command failure is NOT swallowed.
+
+    OMV also deletes the bgproc status file when the underlying command
+    failed (e.g. apt-get exiting non-zero because dpkg was interrupted on
+    the host). The 500 response body still contains the actual error in
+    that case, so it must propagate instead of being treated as "bgproc
+    completed successfully" — otherwise a failed upgrade would silently
+    report success with nothing actually installed.
+    """
+
+    async def _mock_call(service: str, method: str, params: dict | None = None, **_: object) -> object:
+        if service == "Apt":
+            return "/tmp/bgstatus"
+        raise OMVConnectionError(
+            'OMV returned HTTP 500: {"response":null,"error":{"code":0,'
+            '"message":"Failed to execute command \'apt-get ... dist-upgrade\' '
+            "with exit code '100': E: dpkg was interrupted, you mus"
+        )
+
+    coordinator.api.async_call = _mock_call
+    coordinator.async_request_refresh = AsyncMock()
+
+    entity = OMVUpdateEntity(coordinator)
+
+    with (
+        patch("custom_components.omv.update.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(OMVConnectionError, match="Failed to execute command"),
+    ):
+        await entity.async_install(version=None, backup=False)
+
+
+@pytest.mark.asyncio
 async def test_async_install_stops_polling_after_timeout(coordinator) -> None:
     """Test _wait_for_bgproc stops after _MAX_POLLS when process never finishes."""
     still_running = {"filename": "/tmp/bgstatus", "running": True}


### PR DESCRIPTION
## Summary
- `Exec.isRunning` returns HTTP 500 both after a successful bgproc (status file cleaned up) and when the underlying `apt-get`/`dpkg` command itself failed (body still carries the real error). `_wait_for_bgproc` treated every HTTP 500 as success, so a failed dist-upgrade (e.g. host with an interrupted dpkg state) was silently reported to HA as a completed install with nothing actually upgraded.
- Only a bare HTTP 500 (no `"Failed to execute command"` in the body) is now treated as "bgproc completed"; a real command failure is re-raised so HA correctly marks the install as failed.
- Bumps version to 2.6.7.

## Test plan
- [x] `pytest tests/ -q` — 368 passed
- [x] `ruff check` / `ruff format --check`
- [x] New test `test_async_install_raises_when_bgproc_command_itself_failed` reproduces the real-world dpkg-interrupted log and asserts the error now propagates
- [x] Existing `test_async_install_treats_http500_from_bgproc_as_done` still passes (benign 500 still treated as success)
- [ ] CI (lint/test/hacs/hassfest/smoke-test) must pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)