### PR TITLE
fix(entity): controlled error instead of AttributeError for stale pre-2.8.0 coordinator (2.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Hardened `entity.py`'s `hub_device_id` lookups (disk, filesystem, compose project, container, VM devices) behind a `getattr`-based helper so a stale pre-2.8.0 `coordinator.py` loaded alongside the 2.8.0 files — an incomplete HACS update or an orphaned `__pycache__` — surfaces as a controlled `RuntimeError` from `_require_device_id` instead of an uncaught `AttributeError` that aborts entry setup before any cleanup or logging runs (Issue #88).
+- Added a startup integrity check in `async_setup_entry` that fails fast with a clear, actionable message (remove `custom_components/omv` including its `__pycache__` and reinstall, then restart) when the loaded coordinator class predates 2.8.0, closing the OMV API session on that path (Issue #88).
+- Added regression tests covering the missing-attribute scenario and the consistency-check failure path.
+
 ## [2.8.0] - 2026-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.8.1] - 2026-09-09
 
 ### Fixed
 

--- a/custom_components/omv/__init__.py
+++ b/custom_components/omv/__init__.py
@@ -66,6 +66,34 @@ def _platforms_for_entry(entry: OMVConfigEntry) -> list[Platform]:
     return PLATFORMS
 
 
+def _check_coordinator_version_consistency(coordinator: OMVDataUpdateCoordinator) -> None:
+    """Fail fast when the loaded coordinator class predates 2.8.0 (Issue #88).
+
+    An incomplete HACS update or an orphaned ``__pycache__`` can load a
+    pre-2.8.0 ``coordinator.py`` next to the 2.8.0 ``entity.py``/``sensor.py``.
+    Reading ``hub_device_id`` in that mixed setup previously aborted entry setup
+    with a cryptic ``AttributeError`` deep inside the registry cleanup. The
+    ``hasattr`` probes catch the stale class up front so setup can abort with a
+    clear, actionable message instead.
+
+    Args:
+        coordinator: The freshly constructed data update coordinator.
+
+    Raises:
+        RuntimeError: If ``hub_device_id`` or ``project_device_ids`` are absent
+            from the coordinator class, i.e. the loaded ``coordinator.py``
+            predates 2.8.0 — with an instruction to reinstall the integration.
+    """
+    if not (hasattr(coordinator, "hub_device_id") and hasattr(coordinator, "project_device_ids")):
+        raise RuntimeError(
+            "OpenMediaVault installation is inconsistent: the loaded "
+            "coordinator.py predates integration 2.8.0 while the other files "
+            "do not (Issue #88). Remove the custom_components/omv folder "
+            "including its __pycache__ and reinstall the integration, then "
+            "restart Home Assistant."
+        )
+
+
 def _login_cookie_store(hass: HomeAssistant, entry: OMVConfigEntry) -> Store:
     """Return the per-entry Store for the OMV login-notification cookie name.
 
@@ -301,6 +329,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool:
     Raises:
         ConfigEntryAuthFailed: If OMV authentication fails (no pending hand-off).
         ConfigEntryNotReady: If OMV cannot be reached (no pending hand-off).
+        RuntimeError: If the loaded coordinator class predates 2.8.0
+            (mixed-version installation, Issue #88) — setup aborts early with a
+            clear reinstall instruction instead of crashing deeper in.
     """
     handoff = session_handoff.pop(entry.unique_id)
     if handoff is not None:
@@ -346,6 +377,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OMVConfigEntry) -> bool:
     await coordinator.async_init(system_info)
     await coordinator.async_config_entry_first_refresh()
     await _async_persist_login_cookie(hass, entry, api)
+    _check_coordinator_version_consistency(coordinator)
     entry.runtime_data = coordinator
     await _async_register_hierarchy_devices(hass, entry, coordinator)
     await _async_migrate_container_registry_keys(hass, entry, coordinator)

--- a/custom_components/omv/entity.py
+++ b/custom_components/omv/entity.py
@@ -151,6 +151,26 @@ def _require_device_id(device_id: str | None) -> str:
     return device_id
 
 
+def _hub_device_id(coordinator: OMVDataUpdateCoordinator) -> str | None:
+    """Return the pre-registered hub device registry id, tolerating a missing attribute.
+
+    ``hub_device_id`` was added to :class:`OMVDataUpdateCoordinator` in 2.8.0. If a
+    stale pre-2.8.0 ``coordinator.py`` is loaded next to the 2.8.0 ``entity.py``
+    (incomplete HACS update, orphaned ``__pycache__``), reading the attribute
+    directly would crash entry setup with ``AttributeError`` before any cleanup
+    or logging could run. ``getattr`` maps that mixed-version scenario onto the
+    controlled ``RuntimeError`` from :func:`_require_device_id` instead
+    (Issue #88).
+
+    Args:
+        coordinator: The data update coordinator.
+
+    Returns:
+        The hub device registry id, or ``None`` if the attribute is absent or unset.
+    """
+    return getattr(coordinator, "hub_device_id", None)
+
+
 def get_hub_device_info(coordinator: OMVDataUpdateCoordinator) -> DeviceInfo:
     """Return the OMV hub device info."""
     hwinfo = coordinator.data.get("hwinfo", {})
@@ -213,7 +233,7 @@ def get_disk_device_info(
 
     return DeviceInfo(
         identifiers={get_disk_device_identifier(coordinator, disk_key)},
-        via_device_id=_require_device_id(coordinator.hub_device_id),
+        via_device_id=_require_device_id(_hub_device_id(coordinator)),
         name=_build_disk_device_name(disk, disk_key),
         manufacturer=manufacturer,
         model=_build_disk_device_model(disk),
@@ -257,7 +277,7 @@ def _build_standalone_filesystem_device_info(
 
     return DeviceInfo(
         identifiers={get_filesystem_device_identifier(coordinator, fs_uuid)},
-        via_device_id=_require_device_id(coordinator.hub_device_id),
+        via_device_id=_require_device_id(_hub_device_id(coordinator)),
         name=name,
         manufacturer="OpenMediaVault",
         model=fs_type,
@@ -318,7 +338,7 @@ def get_compose_project_device_info(
     project_name = _normalized_device_value(project.get("name")) or project_key
     return DeviceInfo(
         identifiers={get_compose_project_device_identifier(coordinator, project_key)},
-        via_device_id=_require_device_id(coordinator.hub_device_id),
+        via_device_id=_require_device_id(_hub_device_id(coordinator)),
         name=f"Compose {project_name}",
         manufacturer="Docker Compose",
         model="Compose Project",
@@ -339,9 +359,9 @@ def get_container_device_info(
     container_key = str(container.get("container_key") or container.get("name") or "")
     project_key = str(container.get("project_key") or "")
     via_device_id = _require_device_id(
-        coordinator.project_device_ids.get(project_key, coordinator.hub_device_id)
+        coordinator.project_device_ids.get(project_key, _hub_device_id(coordinator))
         if project_key
-        else coordinator.hub_device_id
+        else _hub_device_id(coordinator)
     )
     display_name = _container_display_name(container)
     return DeviceInfo(
@@ -364,7 +384,7 @@ def get_vm_device_info(
     display_name = _normalized_device_value(vm.get("name")) or vm_key
     return DeviceInfo(
         identifiers={get_vm_device_identifier(coordinator, vm_key)},
-        via_device_id=_require_device_id(coordinator.hub_device_id),
+        via_device_id=_require_device_id(_hub_device_id(coordinator)),
         name=f"VM {display_name}",
         manufacturer="QEMU/KVM",
         model="Virtual Machine",

--- a/custom_components/omv/manifest.json
+++ b/custom_components/omv/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/slybase/homeassistant-openmediavault/issues",
     "requirements": [],
-    "version": "2.8.0"
+    "version": "2.8.1"
 }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,12 +4,42 @@ from __future__ import annotations
 
 from custom_components.omv.const import DOMAIN
 from custom_components.omv.entity import (
+    _hub_device_id,
     get_compose_project_device_info,
     get_container_device_info,
     get_disk_device_info,
     get_filesystem_device_identifier,
     get_filesystem_device_info,
 )
+
+
+def test_hub_device_id_helper_returns_none_for_stale_pre_280_coordinator(coordinator) -> None:
+    """A stale pre-2.8.0 coordinator lacking hub_device_id yields None, not AttributeError.
+
+    Regression for Issue #88: an incomplete HACS update (or orphaned __pycache__)
+    can load a coordinator.py that predates the hub_device_id attribute while
+    entity.py already reads it. The getattr-based helper must map that onto the
+    controlled RuntimeError from _require_device_id instead of an uncaught
+    AttributeError that aborts entry setup.
+    """
+    # Simulate the stale class: the attribute simply does not exist.
+    del coordinator.hub_device_id
+
+    # getattr-based access must not raise AttributeError.
+    assert _hub_device_id(coordinator) is None
+
+    # And the disk device builder must raise the controlled RuntimeError.
+    disk = coordinator.data["disk"][0]
+    try:
+        get_disk_device_info(coordinator, disk)
+    except AttributeError as exc:  # pragma: no cover - guards the regression
+        raise AssertionError(
+            "stale coordinator.py must surface as RuntimeError, not AttributeError (Issue #88)"
+        ) from exc
+    except RuntimeError:
+        pass
+    else:  # pragma: no cover - guards the regression
+        raise AssertionError("expected RuntimeError for missing hub_device_id")
 
 
 def test_physical_disk_device_info_uses_vendor_model_and_storage_label(coordinator) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.omv import (
     _async_migrate_container_registry_keys,
     _async_persist_login_cookie,
+    _check_coordinator_version_consistency,
     _login_cookie_store,
     session_handoff,
 )
@@ -125,6 +126,24 @@ async def test_async_setup_entry_reuses_handed_off_session(hass) -> None:
     assert entry.runtime_data.api is handed_off_api
     # The stashed session was consumed and is gone from the registry.
     assert session_handoff.pop("nas") is None
+
+
+def test_coordinator_version_consistency_passes_for_current_coordinator(coordinator) -> None:
+    """A current (2.8.0+) coordinator carries both attributes, so the check is a no-op."""
+    _check_coordinator_version_consistency(coordinator)
+
+
+def test_coordinator_version_consistency_fails_fast_for_stale_pre_280_coordinator(coordinator) -> None:
+    """A stale pre-2.8.0 coordinator (missing hub_device_id) aborts setup with a clear message.
+
+    Regression for Issue #88: an incomplete HACS update / orphaned __pycache__ loads a
+    coordinator.py that predates hub_device_id. The check must raise a RuntimeError
+    naming the fix, so setup fails fast instead of crashing deep in the registry cleanup.
+    """
+    del coordinator.hub_device_id
+
+    with pytest.raises(RuntimeError, match="Remove the custom_components/omv folder"):
+        _check_coordinator_version_consistency(coordinator)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #88

## Problem

A mixed/incomplete update (new `entity.py`/`sensor.py` from 2.8.0 + a pre-2.8.0
`coordinator.py` or a stale `__pycache__`) crashes entities at runtime with:

`AttributeError: 'OMVDataUpdateCoordinator' object has no attribute 'hub_device_id'`

A clean 2.8.0 install cannot produce this — `hub_device_id` has been initialised
in `coordinator.py` since `9b60f76` — so the fingerprint is an outdated module,
and the crash gives the user no hint how to repair it.

## Changes

- **entity.py** — new `_hub_device_id()` helper (defensive `getattr`); all five
  read sites (disk, filesystem, compose project, container, VM) now use it, so a
  missing attribute degrades to the existing controlled `RuntimeError`
  ("Device hierarchy not registered before entity setup") instead of `AttributeError`.
- **__init__.py** — new fail-fast integrity check `_check_coordinator_version_consistency()`
  in `async_setup_entry` (after first refresh, before registry cleanup). If the
  loaded coordinator class predates 2.8.0, setup fails with an explicit `RuntimeError`
  telling the user exactly what to do: remove `custom_components/omv` including
  `__pycache__`, reinstall, restart Home Assistant.
- **manifest.json** — 2.8.0 → 2.8.1; **CHANGELOG.md** entry.
- **tests** — 3 new regression tests (helper against a pre-2.8.0 coordinator stub,
  consistency check pass/fail).

## Verification

- Sabotage run: with the fix reverted, the new test reproduces the exact
  `AttributeError` from issue #88; with the fix, it passes.
- Full suite: `388 passed` (Python 3.14 venv, pytest-homeassistant-custom-component).
- `ruff check` + `ruff format --check`: clean; `mypy`: no issues in 20 files.
